### PR TITLE
WebRTC Signaling Channel

### DIFF
--- a/jsdoc/plugins/hifi.js
+++ b/jsdoc/plugins/hifi.js
@@ -20,7 +20,7 @@ exports.handlers = {
 
         // directories to scan for jsdoc comments
         var dirList = [
-            '../src'
+            '.'
         ];
 
         // only files with this extension will be searched for jsdoc comments.

--- a/src/libraries/networking/NodeType.js
+++ b/src/libraries/networking/NodeType.js
@@ -1,0 +1,47 @@
+//
+//  NodeType.js
+//
+//  Created by David Rowe on 18 May 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License", Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+const NodeType = (function () {
+    // C++  NodeType
+
+    // C++  NodeType_t
+    const DomainServer = "D";
+    const EntityServer = "o";
+    const Agent = "I";
+    const AudioMixer = "M";
+    const AvatarMixer = "W";
+    const AssetServer = "A";
+    const MessagesMixer = "m";
+    const EntityScriptServer = "S";
+    const UpstreamAudioMixer = "B";
+    const UpstreamAvatarMixer = "C";
+    const DownstreamAudioMixer = "a";
+    const DownstreamAvatarMixer = "w";
+    const Unassigned = 1;
+
+    return {
+        DomainServer,
+        EntityServer,
+        Agent,
+        AudioMixer,
+        AvatarMixer,
+        AssetServer,
+        MessagesMixer,
+        EntityScriptServer,
+        UpstreamAudioMixer,
+        UpstreamAvatarMixer,
+        DownstreamAudioMixer,
+        DownstreamAvatarMixer,
+        Unassigned
+    };
+
+}());
+
+export default NodeType;

--- a/src/libraries/networking/webrtc/SignalingChannel.js
+++ b/src/libraries/networking/webrtc/SignalingChannel.js
@@ -1,0 +1,85 @@
+//
+//  SignalingChannel.js
+//
+//  Created by David Rowe on 17 May 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License", Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+// WebRTC signaling channel for establishing WebRTC data channels with the domain server and assignment clients - one signaling
+// channel for all of them. All signaling messages are sent to the domain server which relays assignment client signaling
+// messages as required.
+class SignalingChannel {
+
+    /* eslint-disable no-magic-numbers */
+
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    /* eslint-enable no-magic-numbers */
+
+    #websocket;
+
+    constructor(websocketURL) {
+        if (typeof websocketURL !== "string" || websocketURL === "") {
+            console.error("SignalingChannel: Invalid WebSocket URL!");
+        }
+        this.#websocket = new WebSocket(websocketURL);
+    }
+
+    /* eslint-disable accessor-pairs */
+
+    get readyState() {
+        return this.#websocket.readyState;
+    }
+
+    set onopen(callback) {
+        this.#websocket.onopen = callback;
+    }
+
+    set onclose(callback) {
+        this.#websocket.onclose = callback;
+    }
+
+    set onerror(callback) {
+        this.#websocket.onerror = callback;
+    }
+
+    set onmessage(callback) {
+        this.#websocket.onmessage = function (message) {
+            try {
+                const json = JSON.parse(message.data);
+                callback(json);
+            } catch (e) {
+                console.error("SignalingChannel: Invalid reply received!");
+                if (this.#websocket.onerror) {
+                    this.#websocket.onerror("Invalid reply received!");
+                }
+            }
+        };
+    }
+
+    /* eslint-enable accessor-pairs */
+
+    send(message) {
+        if (this.#websocket.readyState === SignalingChannel.OPEN) {
+            this.#websocket.send(JSON.stringify(message));
+        } else {
+            console.error("SignalingChannel: Channel not open for sending!");
+            if (this.#websocket.onerror) {
+                this.#websocket.onerror("Channel not open for sending!");
+            }
+        }
+    }
+
+    close() {
+        this.#websocket.close();
+    }
+
+}
+
+export default SignalingChannel;

--- a/tests/libraries/networking/webrtc/SignalingChannel.integration.test.js
+++ b/tests/libraries/networking/webrtc/SignalingChannel.integration.test.js
@@ -1,0 +1,93 @@
+//
+//  SignalingChannel.integration.test.js
+//
+//  Created by David Rowe on 17 May 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License", Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/* globals jest */
+
+import SignalingChannel from "../../../../src/libraries/networking/webrtc/SignalingChannel.js";
+import NodeType from "../../../../src/libraries/networking/NodeType.js";
+
+describe("SignalingChannel - integration tests", () => {
+
+    //  Test environment expected: Domain server running on localhost.
+
+    const LOCALHOST_WEBSOCKET = "ws://127.0.0.1:40102";
+    const INVALID_WEBSOCKET = "ws://0.0.0.0:0";
+
+    // Suppress console.error messages from being displayed.
+    const error = jest.spyOn(console, "error").mockImplementation(() => { });  // eslint-disable-line no-empty-function
+
+    test("Can open and close", (done) => {
+        expect.assertions(2);
+        let signalingChannel = new SignalingChannel(LOCALHOST_WEBSOCKET);
+        signalingChannel.onopen = function () {
+            expect(signalingChannel.readyState).toBe(SignalingChannel.OPEN);
+            signalingChannel.close();
+        };
+        signalingChannel.onclose = function () {
+            expect(signalingChannel.readyState).toBe(SignalingChannel.CLOSED);
+            signalingChannel = null;
+            done();
+        };
+    });
+
+    test("Open invalid address fails with an error", (done) => {
+        expect.assertions(1);
+        let signalingChannel = new SignalingChannel(INVALID_WEBSOCKET);
+        signalingChannel.onerror = function () {
+            expect(signalingChannel.readyState).toBe(SignalingChannel.CLOSED);
+            signalingChannel.close();
+            signalingChannel = null;
+            done();
+        };
+    });
+
+    test("Sending when closed fails with an error", (done) => {
+        expect.assertions(2);
+        let signalingChannel = new SignalingChannel(LOCALHOST_WEBSOCKET);
+        function sendMessage() {
+            const echoMessage = { to: NodeType.DomainServer, echo: "Hello" };
+            signalingChannel.send(echoMessage);
+        }
+        signalingChannel.onopen = function () {
+            signalingChannel.close();
+        };
+        signalingChannel.onclose = function () {
+            expect(signalingChannel.readyState).toBe(SignalingChannel.CLOSED);
+            sendMessage();
+        };
+        signalingChannel.onerror = function () {
+            expect(signalingChannel.readyState).toBe(SignalingChannel.CLOSED);
+            signalingChannel = null;
+            done();
+        };
+    });
+
+    test("Can echo test message off domain server", (done) => {
+        expect.assertions(2);
+        let signalingChannel = new SignalingChannel(LOCALHOST_WEBSOCKET);
+        signalingChannel.onopen = function () {
+            const echoMessage = { to: NodeType.DomainServer, echo: "Hello" };
+            signalingChannel.send(echoMessage);
+        };
+        signalingChannel.onmessage = function (message) {
+            expect(message.from).toBe(NodeType.DomainServer);
+            expect(message.echo).toBe("Hello");
+            signalingChannel.close();
+            signalingChannel = null;
+            done();
+        };
+    });
+
+    // WEBRTC TODO: "Can echo test message off messages mixer"
+
+    // Testing that WebRTC signaling messages are able to be used is done through testing higher level function.
+
+    error.mockReset();
+});

--- a/tests/libraries/networking/webrtc/SignalingChannel.integration.test.js
+++ b/tests/libraries/networking/webrtc/SignalingChannel.integration.test.js
@@ -85,6 +85,36 @@ describe("SignalingChannel - integration tests", () => {
         };
     });
 
+    test("Signaling channels are kept separate", (done) => {
+        expect.assertions(2);
+        let signalingChannel1 = new SignalingChannel(LOCALHOST_WEBSOCKET);
+        signalingChannel1.onopen = function () {
+            const echoMessage = { to: NodeType.DomainServer, echo: "Hello" };
+            signalingChannel1.send(echoMessage);
+        };
+        let signalingChannel2 = new SignalingChannel(LOCALHOST_WEBSOCKET);
+        signalingChannel2.onopen = function () {
+            const echoMessage = { to: NodeType.DomainServer, echo: "Goodbye" };
+            signalingChannel2.send(echoMessage);
+        };
+        signalingChannel1.onmessage = function (message) {
+            expect(message.echo).toBe("Hello");
+            signalingChannel1.close();
+            signalingChannel1 = null;
+            if (signalingChannel2 === null) {
+                done();
+            }
+        };
+        signalingChannel2.onmessage = function (message) {
+            expect(message.echo).toBe("Goodbye");
+            signalingChannel2.close();
+            signalingChannel2 = null;
+            if (signalingChannel1 === null) {
+                done();
+            }
+        };
+    });
+
     // WEBRTC TODO: "Can echo test message off messages mixer"
 
     // Testing that WebRTC signaling messages are able to be used is done through testing higher level function.


### PR DESCRIPTION
Implements the WebRTC signaling channel which will be used to set up WebRTC data channel connections between the Web app and the domain server and each assignment client.

Works in conjunction with Vircadia PR: **TBD**

QA: `npm run ...` items succeed. Note: The domain server from the Vircadia PR needs to be running on locahost for `npm run test`