### PR TITLE
Make closing connection more robust

### DIFF
--- a/src/libraries/networking/webrtc/WebRTCDataChannel.js
+++ b/src/libraries/networking/webrtc/WebRTCDataChannel.js
@@ -288,8 +288,9 @@ class WebRTCDataChannel {
     close() {
         this.#_readyState = WebRTCDataChannel.CLOSING;
         if (this.#_dataChannel) {
-            this.#_dataChannel.close();  // Closes the peer connection.
-        } else if (this.#_peerConnection) {
+            this.#_dataChannel.close();
+        }
+        if (this.#_peerConnection) {
             this.#_peerConnection.close();
         } else {
             this.#_readyState = WebRTCDataChannel.CLOSED;


### PR DESCRIPTION
Works in conjunction with Vircadia PR: https://github.com/vircadia/vircadia/pull/1238

QA: `npm run test` succeeds. Note: The domain server from the Vircadia PR needs to be running on locahost for npm run test.