### PR TITLE
Package the Web SDK as a module

### DIFF
--- a/jsdoc/sdk-mainpage.md
+++ b/jsdoc/sdk-mainpage.md
@@ -16,8 +16,14 @@ from the SDK JavaScript.
     ```
     npm install --save-prod <path-to-vircadia-web-sdk-folder>
 
-    import { Vircadia, DomainServer } from "@vircadia/web-sdk/Vircadia";
+    import { Vircadia, DomainServer } from "@vircadia/web-sdk";
     ```
+
+- You can also import only specific modules if you wish:
+    ```
+    import { Vircadia, DomainServer } from "@vircadia/web-sdk/modules/Vircadia.js";
+    ```
+
 - Import directly from the SDK JavaScript:
     ```
     import { Vircadia, DomainServer } from "<path>/Vircadia.js";

--- a/jsdoc/sdk-mainpage.md
+++ b/jsdoc/sdk-mainpage.md
@@ -19,7 +19,7 @@ from the SDK JavaScript.
     import { Vircadia, DomainServer } from "@vircadia/web-sdk";
     ```
 
-- You can also import only specific modules if you wish:
+- You can also only import specific modules if you wish:
     ```
     import { Vircadia, DomainServer } from "@vircadia/web-sdk/modules/Vircadia.js";
     ```

--- a/jsdoc/sdk-mainpage.md
+++ b/jsdoc/sdk-mainpage.md
@@ -14,9 +14,9 @@ from the SDK JavaScript.
 
 - Install the SDK package in your project and import, for example:
     ```
-    install --save-prod <path-to-vircadia-web-sdk-folder>
+    npm install --save-prod <path-to-vircadia-web-sdk-folder>
 
-    import { Vircadia, DomainServer } from "Vircadia, for example";
+    import { Vircadia, DomainServer } from "@vircadia/web-sdk/Vircadia";
     ```
 - Import directly from the SDK JavaScript:
     ```

--- a/jsdoc/sdk-mainpage.md
+++ b/jsdoc/sdk-mainpage.md
@@ -9,6 +9,22 @@ This SDK provides interfaces to:
 
 <hr />
 
+To use the API namespaces, import those that you want to use &mdash; either from the SDK package installed in your project or
+from the SDK JavaScript.
+
+- Install the SDK package in your project and import, for example:
+    ```
+    install --save-prod <path-to-vircadia-web-sdk-folder>
+
+    import { Vircadia, DomainServer } from "Vircadia, for example";
+    ```
+- Import directly from the SDK JavaScript:
+    ```
+    import { Vircadia, DomainServer } from "<path>/Vircadia.js";
+    ```
+
+<hr />
+
 For scripting API documentation, see the [Vircadia API Reference](https://apidocs.vircadia.dev).
 
 To learn more about using Vircadia and exploring the metaverse, see the [User Documentation](https://docs.vircadia.dev).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     },
     "license": "Apache-2.0",
     "exports": {
-        ".": "./src",
+        ".": "./src/Vircadia.js",
+        "./modules/": "./src/",
         "./Vircadia": "./src/Vircadia.js",
         "./DomainServer": "./src/DomainServer.js"
     },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "vircadia-web-sdk",
+    "name": "@vircadia/web-sdk",
     "version": "0.0.1",
     "productName": "Vircadia Web SDK",
     "description": "Vircadia Web SDK for virtual worlds.",
@@ -10,7 +10,11 @@
         "url": "https://github.com/vircadia/vircadia-web-sdk.git"
     },
     "license": "Apache-2.0",
-    "private": true,
+    "exports": {
+        ".": "./src",
+        "./Vircadia": "./src/Vircadia.js",
+        "./DomainServer": "./src/DomainServer.js"
+    },
     "scripts": {
         "watch": "webpack --watch --mode production",
         "build": "webpack --mode production",

--- a/src/DomainServer.js
+++ b/src/DomainServer.js
@@ -1,7 +1,7 @@
 //
 //  DomainServer.js
 //
-//  Vircadia Web SDK.
+//  Vircadia Web SDK's Domain Server API.
 //
 //  Created by David Rowe on 8 Jul 2021.
 //  Copyright 2021 Vircadia contributors.
@@ -14,8 +14,11 @@
  *  The <code>DomainServer</code> API provides the interface for connecting to and interacting with a domain server.
  *
  *  @namespace DomainServer
+ *  @property {boolean} isConnected - <code>true</code> if connected to the domain, <code>false</code> if not connected.
  */
 const DomainServer = new (class {
+
+    isConnected = false;
 
 })();
 

--- a/src/Vircadia.js
+++ b/src/Vircadia.js
@@ -11,12 +11,7 @@
 //
 
 /*@sdkdoc
- *  This is the Vircadia SDK.
- *
- *  <p>To use the API namespaces, import those that you want to use, for example:</p>
- *  <pre>
- *  import { Vircadia, DomainServer } from "Vircadia.js";
- *  </pre>
+ *  The <code>Vircadia</code> API provides information on the Vircadia SDK.
  *
  *  @namespace Vircadia
  *  @property {string} version - The version number of the SDK.

--- a/src/Vircadia.js
+++ b/src/Vircadia.js
@@ -12,24 +12,21 @@
 
 /*@sdkdoc
  *  This is the Vircadia SDK.
- *  <p>C++: This abstracts out key components of the native Vircadia Interface app.</p>
+ *
+ *  <p>To use the API namespaces, import those that you want to use, for example:</p>
+ *  <pre>
+ *  import { Vircadia, DomainServer } from "Vircadia.js";
+ *  </pre>
  *
  *  @namespace Vircadia
+ *  @property {string} version - The version number of the SDK.
  */
-const Vircadia = (function () {
+const Vircadia = new (class {
 
-    /**
-     *  Says hello to the world.
-     *  @function Vircadia.helloWorld
-     */
-    function helloWorld() {
-        console.log("Hello world!");
-    }
+    version = "0.0.1";
 
-    return {
-        helloWorld
-    };
-
-}());
+})();
 
 export default Vircadia;
+export { Vircadia };
+export { default as DomainServer } from "./DomainServer.js";

--- a/src/Vircadia.js
+++ b/src/Vircadia.js
@@ -1,0 +1,35 @@
+//
+//  Vircadia.js
+//
+//  Vircadia Web SDK.
+//
+//  Created by David Rowe on 9 May 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/*@sdkdoc
+ *  This is the Vircadia SDK.
+ *  <p>C++: This abstracts out key components of the native Vircadia Interface app.</p>
+ *
+ *  @namespace Vircadia
+ */
+const Vircadia = (function () {
+
+    /**
+     *  Says hello to the world.
+     *  @function Vircadia.helloWorld
+     */
+    function helloWorld() {
+        console.log("Hello world!");
+    }
+
+    return {
+        helloWorld
+    };
+
+}());
+
+export default Vircadia;

--- a/tests/DomainServer.integration.test.js
+++ b/tests/DomainServer.integration.test.js
@@ -8,10 +8,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import DomainServer from "../src/DomainServer.js";
-
-import TestConfig from "./test.config.json";
-
 
 describe("DomainServer - integration tests", () => {
 

--- a/tests/DomainServer.unit.test.js
+++ b/tests/DomainServer.unit.test.js
@@ -13,8 +13,8 @@ import DomainServer from "../src/DomainServer.js";
 
 describe("DomainServer - unit tests", () => {
 
-    test("Empty test", () => {
-        //
+    test("Is connected", () => {
+        expect(DomainServer.isConnected).toBe(false);
     });
 
 });

--- a/tests/Vircadia.integration.test.js
+++ b/tests/Vircadia.integration.test.js
@@ -1,0 +1,21 @@
+//
+//  Vircadia.integration.test.js
+//
+//  Created by David Rowe on 11 Jul 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { Vircadia, DomainServer } from "../src/Vircadia.js";
+
+
+describe("Vircadia - integration tests", () => {
+
+    test("Multiple API import", () => {
+        expect(Vircadia).toBeDefined();
+        expect(DomainServer).toBeDefined();
+    });
+
+});

--- a/tests/Vircadia.unit.test.js
+++ b/tests/Vircadia.unit.test.js
@@ -1,0 +1,21 @@
+//
+//  Vircadia.unit.test.js
+//
+//  Created by David Rowe on 11 Jul 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import Vircadia from "../src/Vircadia.js";
+
+
+describe("Vircadia - unit tests", () => {
+
+    test("Version number", () => {
+        expect(typeof Vircadia.version).toBe("string");
+        expect(Vircadia.version.length).toBeGreaterThan(0);
+    });
+
+});


### PR DESCRIPTION
This is an alternative to PR https://github.com/vircadia/vircadia-web-sdk/pull/16 

QA
- See the user instructions in sdk-mainpage.md. (This file is the home page of the SDK user docs.)
- `npm run test Vircadia.integration Vircadia.unit DomainServer.integration DomainServer.unit`