### PR TITLE
Changes to package.json enabling "npm pack" to create npm installable package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,10 @@
         "url": "https://github.com/vircadia/vircadia-web-sdk.git"
     },
     "license": "Apache-2.0",
-    "exports": {
-        ".": "./src/Vircadia.ts",
-        "./modules/": "./src/",
-        "./Vircadia": "./src/Vircadia.ts",
-        "./DomainServer": "./src/DomainServer.ts"
-    },
-    "main": "Vircadia.ts",
+    "main": "dist/Vircadia.js",
+    "files": [
+        "dist"
+    ],
     "scripts": {
         "build": "webpack --mode production",
         "watch": "webpack --watch --mode development",


### PR DESCRIPTION
With this change to package.json, I can do "npm pack" which creates a tgz package file that can be "npm install FILE"ed. The "npm pack" is done after an "npm run build" as the package just includes the 'dist/' directory. 

At the moment all the .d.ts files are also included and that may be changed later to create a later types file.