### PR TITLE
A simple script for generating type declarations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     ],
     "scripts": {
         "build": "webpack --mode production",
+        "build:types": "tsc -d --out dist/Vircadia.js --declarationMap --emitDeclarationOnly",
         "watch": "webpack --watch --mode development",
         "clean": "tsc --build --clean",
         "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ],
     "scripts": {
         "build": "webpack --mode production",
-        "build:types": "tsc -d --out dist/Vircadia.js --declarationMap --emitDeclarationOnly",
+        "build:types": "tsc --project tsconfig.types.json",
         "watch": "webpack --watch --mode development",
         "clean": "tsc --build --clean",
         "lint": "eslint .",

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -15,11 +15,6 @@
         "useDefineForClassFields": true
     },
     "include": [
-        "./src/**/*",
-        "./typings/**/*"
-    ],
-    "exclude": [
-        "./node_modules/**/*",
-        "./src/domain/worklets/**/*"
+        "./src/Vircadia.ts"
     ]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "outFile": "./dist/Vircadia.js",
+        "declaration": true,
+        "declarationMap": true,
+        "emitDeclarationOnly": true,
+        "allowJs": true,
+        "target": "ESNext",
+        "lib": [ "ES2020", "DOM" ],
+        "sourceMap": false,
+        "esModuleInterop": true,
+        "moduleResolution": "Node",
+        "skipLibCheck": true,
+        "preserveConstEnums": true,
+        "useDefineForClassFields": true
+    },
+    "include": [
+        "./src/**/*",
+        "./typings/**/*"
+    ],
+    "exclude": [
+        "./node_modules/**/*",
+        "./src/domain/worklets/**/*"
+    ]
+}


### PR DESCRIPTION
I've used the compiler to generate the combined .d.ts file here and ran into a very bizarre issue - once the .d.ts file is generated the subsequent builds fail with duplicate identifier error (TS2300) for the two audio worklets. I couldn't figure out why this is happening so I had to just exclude those from the declarations, which I guess makes sense as there might be other internals that we might want to exclude in general, but nevertheless it's very strange that a file in dist folder can affect the build process.