### PR TITLE
Explicitly disconnect example app from domain upon window closing.

### DIFF
--- a/example/interface.js
+++ b/example/interface.js
@@ -351,4 +351,8 @@ import { Vircadia, DomainServer, AudioMixer, AvatarMixer, MessageMixer, Uuid } f
 
     document.getElementById("sdkVersion").innerText = Vircadia.version;
 
+    window.addEventListener("beforeunload", function () {
+        domainServer.disconnect();
+    });
+
 }());


### PR DESCRIPTION
Prevents domain server crash when close or refresh SDK example app window while connected to domain server.