### PR TITLE
Implement packet (un)obfuscation support.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -236,7 +236,7 @@ module.exports = {
         "require-unicode-regexp": "error",
         "vars-on-top": "error",
         "wrap-iife": ["error", "outside"],
-        "yoda": "error",
+        // "yoda": "error",  // Want to use ranges without needing extra parentheses.
 
         // Strict mode.
         "strict": ["error", "safe"],

--- a/src/domain/networking/udt/Connection.ts
+++ b/src/domain/networking/udt/Connection.ts
@@ -16,6 +16,7 @@ import PendingReceivedMessage from "./PendingReceivedMessage";
 import SendQueue from "./SendQueue";
 import SequenceNumber from "./SequenceNumber";
 import Socket from "./Socket";
+import UDT from "./UDT";
 import NLPacketList from "../NLPacketList";
 import SockAddr from "../SockAddr";
 import assert from "../../shared/assert";
@@ -140,7 +141,7 @@ class Connection {
         if (!this.#_hasReceivedHandshake) {
             // Refuse to process any packets until we've received the handshake.
             // Send handshake request to re-request a handshake.
-            if (Socket.UDT_CONNECTION_DEBUG) {
+            if (UDT.UDT_CONNECTION_DEBUG) {
                 console.log("[networking] Received packet before receiving handshake, sending HandshakeRequest.");
             }
             this.#sendHandshakeRequest();
@@ -264,7 +265,7 @@ class Connection {
         // tell our current send queue to go down and reset our ptr to it to null
         this.#stopSendQueue();
 
-        if (Socket.UDT_CONNECTION_DEBUG) {
+        if (UDT.UDT_CONNECTION_DEBUG) {
             console.log("[networking] Connection to", this.#_destination.toString(), "has stopped its SendQueue.");
         }
     };
@@ -382,7 +383,7 @@ class Connection {
             // The server sent us a handshake. We assume this means that state should be reset as long as we haven't received
             // a handshake yet, or we have and we've received some data.
 
-            if (Socket.UDT_CONNECTION_DEBUG) {
+            if (UDT.UDT_CONNECTION_DEBUG) {
                 if (initialSequenceNumber.isNotEqualTo(this.#_initialReceiveSequenceNumber)) {
                     console.log("[networking] Resetting receive state, received a new initial sequence number in handshake.");
                 }
@@ -462,7 +463,7 @@ class Connection {
                     this.#_lastMessageNumber, this.#_hasReceivedHandshakeACK);
             }
 
-            if (Socket.UDT_CONNECTION_DEBUG) {
+            if (UDT.UDT_CONNECTION_DEBUG) {
                 console.log("[networking] Created SendQueue for connection to", this.#_destination.toString());
             }
 

--- a/src/domain/networking/udt/SendQueue.ts
+++ b/src/domain/networking/udt/SendQueue.ts
@@ -14,6 +14,7 @@ import Packet from "./Packet";
 import PacketQueue from "./PacketQueue";
 import SequenceNumber, { SequenceNumberValue } from "./SequenceNumber";
 import Socket from "./Socket";
+import UDT from "./UDT";
 import NLPacketList from "../NLPacketList";
 import SockAddr from "../SockAddr";
 import assert from "../../shared/assert";
@@ -375,7 +376,7 @@ class SendQueue {
                     const level = entry.first < 2 ? 0 : (entry.first - 2) % 4;
 
                     if (level !== Packet.ObfuscationLevel.NoObfuscation) {
-                        if (Socket.UDT_CONNECTION_DEBUG) {
+                        if (UDT.UDT_CONNECTION_DEBUG) {
                             const messageData = resendPacket.getMessageData();
                             let debugString = `Obfuscating packet ${messageData.sequenceNumber} with level ${level}`;
                             if (resendPacket.isPartOfMessage()) {
@@ -488,7 +489,7 @@ class SendQueue {
                     const notified = await this.#_emptyCondition.waitFor(EMPTY_QUEUES_INACTIVE_TIMEOUT_MS);
 
                     if (!notified && (this.#_packets.isEmpty() || this.#isFlowWindowFull()) && this.#_naks.isEmpty()) {
-                        if (Socket.UDT_CONNECTION_DEBUG) {
+                        if (UDT.UDT_CONNECTION_DEBUG) {
                             const S_TO_MS = 1000;
                             console.log("[networking] SendQueue to", this.#_destination.toString(), "has been empty for",
                                 EMPTY_QUEUES_INACTIVE_TIMEOUT_MS / S_TO_MS, "seconds and receiver has ACKed all packets.",
@@ -580,14 +581,14 @@ class SendQueue {
 
         if (this.#_state === SendQueue.#State.Stopped) {
             // We've already been asked to stop before we even got a chance to start; don't start now.
-            if (Socket.UDT_CONNECTION_DEBUG) {
+            if (UDT.UDT_CONNECTION_DEBUG) {
                 console.log("[networking] SendQueue asked to run after being told to stop. Will not run.");
             }
             return;
         }
         if (this.#_state === SendQueue.#State.Running) {
             // We're already running; don't start another run.
-            if (Socket.UDT_CONNECTION_DEBUG) {
+            if (UDT.UDT_CONNECTION_DEBUG) {
                 console.log("[networking] SendQueue asked to run but is already running. Will not re-run.");
             }
             return;

--- a/src/domain/networking/udt/Socket.ts
+++ b/src/domain/networking/udt/Socket.ts
@@ -70,8 +70,6 @@ class Socket {
         Socket.CONNECTED
     ];
 
-    static UDT_CONNECTION_DEBUG = false;
-
 
     // Use WebRTCSocket directly without going through an intermediary NetworkSocket as is done in C++.
     #_webrtcSocket: WebRTCSocket;
@@ -165,7 +163,7 @@ class Socket {
 
         // eslint-disable-next-line @typescript-eslint/dot-notation
         const connectionErased = this.#_connectionsHash.delete(sockAddr.getPort());
-        if (connectionErased && Socket.UDT_CONNECTION_DEBUG) {
+        if (connectionErased && UDT.UDT_CONNECTION_DEBUG) {
             console.log("[networking] Socket.cleanupConnection called for connection to", sockAddr.toString());
         }
     }
@@ -443,7 +441,7 @@ class Socket {
                             || !connection.processReceivedSequenceNumber(new SequenceNumber(messageData.sequenceNumber)
                             /* , packet.getDataSize(), packet.getPayloadSize() */)) {
                             // The connection could not be created or indicated that we should not continue processing packet.
-                            if (Socket.UDT_CONNECTION_DEBUG) {
+                            if (UDT.UDT_CONNECTION_DEBUG) {
                                 console.log("[networking] Can't process packet: type", NLPacket.typeInHeader(packet),
                                     ", version", NLPacket.versionInHeader(packet));
 
@@ -502,7 +500,7 @@ class Socket {
         const connection = this.#findOrCreateConnection(sockAddr);
         if (connection) {
             connection.sendReliablePacketList(packetList);
-        } else if (Socket.UDT_CONNECTION_DEBUG) {
+        } else if (UDT.UDT_CONNECTION_DEBUG) {
             console.log("[networking] Socket.writeReliablePacketList refusing to send packet list - no connection was created");
         }
     }
@@ -517,7 +515,7 @@ class Socket {
 
             if (filterCreate && this.#_connectionCreationFilterOperator && !this.#_connectionCreationFilterOperator(sockAddr)) {
                 // The connection creation filter did not allow us to create a new connection.
-                if (Socket.UDT_CONNECTION_DEBUG) {
+                if (UDT.UDT_CONNECTION_DEBUG) {
                     console.log("[networking] Socket.findOrCreateConnection refusing to create Connection class for",
                         sockAddr.toString(), "due to connection creation filter");
                 }

--- a/src/domain/networking/udt/UDT.ts
+++ b/src/domain/networking/udt/UDT.ts
@@ -15,49 +15,38 @@
  *  @namespace UDT
  *  @property {number} UDP_IPV4_HEADER_SIZE=28 The number of bytes in a UDP/IPV4 packet header.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} MAX_PACKET_SIZE=1464 The maximum {@link BasePacket} Vircadia protocol payload size.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {boolean} LITTLE_ENDIAN=true - Read / write DataView values in little-endian format.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {boolean} BIG_ENDIAN=false - Read / write DataView values in big-endian format.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *
  *  @property {number} MESSAGE_NUMBER_SIZE=30 - Number of bits in the message number.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *
  *  @property {number} OBFUSCATION_LEVEL_OFFSET=27 - Number of bits the obfuscation level value is offset.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} PACKET_POSITION_OFFSET=30 - Number of bits the packet position value is offset.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
 
   *  @property {number} CONTROL_BIT_MASK=0x80000000 - Mask for reading / writing the control bit.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} RELIABILITY_BIT_MASK=0x40000000 - Mask for reading / writing the reliability bit.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} MESSAGE_BIT_MASK=0x20000000 - Mask for reading / writing the message bit.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} OBFUSCATION_LEVEL_BIT_MASK=0x18000000 - Mask for reading / writing the obfuscation level bits.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} SEQUENCE_NUMBER_BIT_MASK=0x7fffff - Mask for reading / writing the sequence number.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} BIT_FIELD_MASK=0xf8000000 - Mask for reading / writing the packet bit fields.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
  *  @property {number} MESSAGE_NUMBER_MASK=0x3fffffff - Mask for reading / writing the message number.
  *      <em>Read-only.</em>
- *      <p><em>Static</em></p>
+ *
+ *  @property {boolean} UDT_CONNECTION_DEBUG=false - Internal setting for debugging UDT communications.
+ *      <em>Read-only.</em>
  */
 const UDT = new class {
     // C++: udt - Constants.h
@@ -87,6 +76,10 @@ const UDT = new class {
     readonly SEQUENCE_NUMBER_BIT_MASK = 0x7ffffff;
     readonly BIT_FIELD_MASK = 0xF8000000;
     readonly MESSAGE_NUMBER_MASK = 0x3fffffff;
+
+
+    // Internal debug
+    readonly UDT_CONNECTION_DEBUG = false;
 
 }();
 


### PR DESCRIPTION
The following messages will no longer occur in the browser log:
```
Packet() : Undo obfuscation : Not implemented!
ERROR - Unknown packet type in versionForPacketType() : 105
[networking]  Packet version mismatch on 105 - Sender WebRTC 0.0.0.0:3 sent 83 but 0 expected.
```
And similar for packets 115 and 124.

