### PR TITLE
Overriding properties of test.config.json with environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ npm run lint-path <path>
 ### Run tests
 
 Unit tests can be run without any external dependencies but integration tests require a domain server to be running on
-`localhost` or other location specified in `./tests/test.config.json`. The location and other values of the config JSON can be overridden with environment variables, using the same property names, but prefixed with "VIRCADIA_".
+`localhost` or other location specified in `./tests/test.config.json`. The location and other values of the config JSON can be
+overridden with environment variables, using the same property names, but prefixed with "VIRCADIA_".
+
 
 All tests:
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm run lint-path <path>
 ### Run tests
 
 Unit tests can be run without any external dependencies but integration tests require a domain server to be running on
-`localhost` or other location specified in `test.config.json`.
+`localhost` or other location specified in `./tests/test.config.json`. The location and other values of the config JSON can be overridden with environment variables, using the same property names, but prefixed with "VIRCADIA_".
 
 All tests:
 ```

--- a/tests/AudioMixer.integration.test.js
+++ b/tests/AudioMixer.integration.test.js
@@ -11,7 +11,7 @@
 import DomainServer from "../src/DomainServer";
 import AudioMixer from "../src/AudioMixer";
 
-import TestConfig from "./test.config.json";
+import TestConfig from "./test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/AvatarMixer.integration.test.js
+++ b/tests/AvatarMixer.integration.test.js
@@ -11,7 +11,7 @@
 import DomainServer from "../src/DomainServer";
 import AvatarMixer from "../src/AvatarMixer";
 
-import TestConfig from "./test.config.json";
+import TestConfig from "./test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/DomainServer.integration.test.js
+++ b/tests/DomainServer.integration.test.js
@@ -11,7 +11,7 @@
 import DomainServer from "../src/DomainServer";
 import Uuid from "../src/domain/shared/Uuid";
 
-import TestConfig from "./test.config.json";
+import TestConfig from "./test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 import { protocolVersionsSignature } from "../src/domain/networking/udt/PacketHeaders";

--- a/tests/MessageMixer.integration.test.js
+++ b/tests/MessageMixer.integration.test.js
@@ -11,7 +11,7 @@
 import DomainServer from "../src/DomainServer";
 import MessageMixer from "../src/MessageMixer";
 
-import TestConfig from "./test.config.json";
+import TestConfig from "./test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/domain/AssignmentClient.integration.test.js
+++ b/tests/domain/AssignmentClient.integration.test.js
@@ -12,7 +12,7 @@ import DomainServer from "../../src/DomainServer";
 import AssignmentClient from "../../src/domain/AssignmentClient";
 import NodeType from "../../src/domain/networking/NodeType";
 
-import TestConfig from "../test.config.json";
+import TestConfig from "../test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/domain/networking/AddressManager.unit.test.js
+++ b/tests/domain/networking/AddressManager.unit.test.js
@@ -11,7 +11,7 @@
 import AddressManager from "../../../src/domain/networking/AddressManager";
 import ContextManager from "../../../src/domain/shared/ContextManager";
 
-import TestConfig from "../../test.config.json";
+import TestConfig from "../../test.config.js";
 
 
 describe("AddressManager - unit tests", () => {

--- a/tests/domain/networking/DomainHandler.unit.test.js
+++ b/tests/domain/networking/DomainHandler.unit.test.js
@@ -15,7 +15,7 @@ import SignalEmitter from "../../../src/domain/shared/SignalEmitter";
 import Uuid from "../../../src/domain/shared/Uuid";
 import DomainHandler from "../../../src/domain/networking/DomainHandler";
 
-import TestConfig from "../../test.config.json";
+import TestConfig from "../../test.config.js";
 
 
 describe("DomainHandler - integration tests", () => {

--- a/tests/domain/networking/udt/Socket.integration.test.js
+++ b/tests/domain/networking/udt/Socket.integration.test.js
@@ -11,7 +11,7 @@
 import NodeType from "../../../../src/domain/networking/NodeType";
 import Socket from "../../../../src/domain/networking/udt/Socket";
 
-import TestConfig from "../../../test.config.json";
+import TestConfig from "../../../test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/domain/networking/udt/Socket.unit.test.js
+++ b/tests/domain/networking/udt/Socket.unit.test.js
@@ -11,7 +11,7 @@
 import NodeType from "../../../../src/domain/networking/NodeType";
 import Socket from "../../../../src/domain/networking/udt/Socket";
 
-import TestConfig from "../../../test.config.json";
+import TestConfig from "../../../test.config.js";
 
 
 describe("Socket - unit tests", () => {

--- a/tests/domain/networking/webrtc/WebRTCDataChannel.integration.test.js
+++ b/tests/domain/networking/webrtc/WebRTCDataChannel.integration.test.js
@@ -12,7 +12,7 @@ import WebRTCDataChannel from "../../../../src/domain/networking/webrtc/WebRTCDa
 import WebRTCSignalingChannel from "../../../../src/domain/networking/webrtc/WebRTCSignalingChannel";
 import NodeType from "../../../../src/domain/networking/NodeType";
 
-import TestConfig from "../../../test.config.json";
+import TestConfig from "../../../test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/domain/networking/webrtc/WebRTCSignalingChannel.integration.test.js
+++ b/tests/domain/networking/webrtc/WebRTCSignalingChannel.integration.test.js
@@ -11,7 +11,7 @@
 import WebRTCSignalingChannel from "../../../../src/domain/networking/webrtc/WebRTCSignalingChannel";
 import NodeType from "../../../../src/domain/networking/NodeType";
 
-import TestConfig from "../../../test.config.json";
+import TestConfig from "../../../test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/domain/networking/webrtc/WebRTCSocket.integration.test.js
+++ b/tests/domain/networking/webrtc/WebRTCSocket.integration.test.js
@@ -11,7 +11,7 @@
 import NodeType from "../../../../src/domain/networking/NodeType";
 import WebRTCSocket from "../../../../src/domain/networking/webrtc/WebRTCSocket";
 
-import TestConfig from "../../../test.config.json";
+import TestConfig from "../../../test.config.js";
 
 import "wrtc";  // WebRTC Node.js package.
 

--- a/tests/test.config.js
+++ b/tests/test.config.js
@@ -1,0 +1,12 @@
+import TestConfig from "./test.config.json";
+
+const env = process && process.env || {};
+
+for (const key of Object.keys(TestConfig)) {
+    const envKey = "VIRCADIA_" + key;
+    if (typeof env[envKey] !== "undefined") {
+        TestConfig[key] = env[envKey];
+    }
+}
+
+export default TestConfig;


### PR DESCRIPTION
Using environment variables is the only way I could find to specify parameters through CLI with jest, without lot of ugly hacks. 
The variables names correspond to properties in tests/test.config.json, just prefixed with VIRCADIA_.
There is no portable way to use this but on linux it looks like this
```
env VIRCADIA_SERVER_DOMAIN_URL="example.com" VIRCADIA_SERVER_SIGNALING_SOCKET_URL="wss://example.com:40102" npm run test
```
and there should be something similar in powershell I guess.