### PR TITLE
Fix TypeScript .d.ts files not being found when using the SDK.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "license": "Apache-2.0",
     "main": "dist/Vircadia.js",
+    "types": "dist/src/Vircadia.d.ts",
     "files": [
         "dist"
     ],


### PR DESCRIPTION
This change makes the TypeScript types be found when importing SDK items from an NPMJS package in a TypeScript project.