### PR TITLE
Receive entity server packets.

### DIFF
--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -12,6 +12,7 @@ import Node from "./domain/networking/Node";
 import NodeList from "./domain/networking/NodeList";
 import NodeType, { NodeTypeValue } from "./domain/networking/NodeType";
 import OctreeConstants from "./domain/octree/OctreeConstants";
+import OctreePacketProcessor from "./domain/octree/OctreePacketProcessor";
 import OctreeQuery from "./domain/octree/OctreeQuery";
 import PacketScribe from "./domain/networking/packets/PacketScribe";
 import Camera from "./domain/shared/Camera";
@@ -87,6 +88,9 @@ class EntityServer extends AssignmentClient {
     #_nodeList: NodeList;
 
     #_octreeQuery = new OctreeQuery(true);
+    // eslint-disable-next-line
+    // @ts-ignore
+    #_octreeProcessor;
     #_maxOctreePPS = OctreeConstants.DEFAULT_MAX_OCTREE_PPS;
     #_queryExpiry = 0;
     #_physicsEnabled = true;
@@ -98,6 +102,8 @@ class EntityServer extends AssignmentClient {
         // Context
         this.#_camera = ContextManager.get(contextID, Camera) as Camera;
         this.#_nodeList = ContextManager.get(contextID, NodeList) as NodeList;
+        ContextManager.set(contextID, OctreePacketProcessor, contextID);
+        this.#_octreeProcessor = ContextManager.get(contextID, OctreePacketProcessor) as OctreePacketProcessor;
 
         // C++  Application::Application()
         this.#_nodeList.nodeActivated.connect(this.#nodeActivated);

--- a/src/domain/networking/PacketReceiver.ts
+++ b/src/domain/networking/PacketReceiver.ts
@@ -137,6 +137,7 @@ class PacketReceiver {
         // C++ bool PacketReceiver::registerListenerForTypes(PacketTypeList types, const ListenerReferencePointer& listener)
 
         for (const type of types) {
+            // WEBRTC TODO: Address further code.
             this.registerListener(type, listener);
         }
 

--- a/src/domain/networking/PacketReceiver.ts
+++ b/src/domain/networking/PacketReceiver.ts
@@ -127,6 +127,22 @@ class PacketReceiver {
         // WEBRTC TODO: Address further C++ code.
     }
 
+    /*@devdoc
+     *  Registers a listener function to invoke for multiple {@link PacketType(1)|PacketType}.
+     *  @param {PacketType[]} types - An array containing the types to register.
+     *  @param {PacketReceiver.ListenerReference} listener - The reference to the listener function.
+     *  @returns {boolean} <code>true</code> if the listener was successfully registered, <code>false</code> if it wasn't.
+     */
+    registerListenerForTypes(types: PacketTypeValue[], listener: ListenerReference): boolean {
+        // C++ bool PacketReceiver::registerListenerForTypes(PacketTypeList types, const ListenerReferencePointer& listener)
+
+        for (const type of types) {
+            this.registerListener(type, listener);
+        }
+
+        return true;
+    }
+
 
     /*@devdoc
      *  Invokes the listener registered for an {@link NLPacket} per its PacketType.

--- a/src/domain/octree/OctreePacketProcessor.ts
+++ b/src/domain/octree/OctreePacketProcessor.ts
@@ -17,7 +17,7 @@ import ReceivedMessage from "../networking/ReceivedMessage";
 
 
 /*@devdoc
- *  The <code>OctreePacketProcessor</code> class handles processing of incoming voxel packets.
+ *  The <code>OctreePacketProcessor</code> class handles processing of incoming octree packets.
  *  <p>C++: <code>class OctreePacketProcessor : public ReceivedPacketProcessor</code></p>
  *
  *  @class OctreePacketProcessor
@@ -27,7 +27,7 @@ import ReceivedMessage from "../networking/ReceivedMessage";
  */
 // WEBRTC TODO:  Extend ReceivedPacketProcessor.
 class OctreePacketProcessor {
-    // C++  OctreePacketProcessor.cpp
+    // C++  class OctreePacketProcessor : public ReceivedPacketProcessor
 
 
     static readonly contextItemType = "OctreePacketProcessor";
@@ -53,7 +53,8 @@ class OctreePacketProcessor {
         // C++ packetReceiver.registerDirectListenerForTypes() is used but in TypeScript we can use the non-direct variant of
         // the method.
         // Also, processPacket() is called directly unlike in the C++ where received packets are pushed to a queue
-        // via OctreePacketProcessor::handleOctreePacket().
+        // via OctreePacketProcessor::handleOctreePacket(). We can process the packet directly because we send the contents
+        // off to the user app to handle.
         this.#_packetReceiver.registerListenerForTypes(octreePackets,
             PacketReceiver.makeSourcedListenerReference(this.#processPacket));
     }
@@ -71,10 +72,10 @@ class OctreePacketProcessor {
             case PacketType.EntityData:
             case PacketType.EntityErase:
             case PacketType.EntityQueryInitialResultsComplete:
-                console.warn("OctreePacketProcessor: Packet type %d not processed: ", packetType);
+                console.error("OctreePacketProcessor: Packet type not processed: ", packetType);
                 break;
             default:
-                console.error("ERROR - Unknown packet type in processPacket() :", packetType);
+                console.error("ERROR - Unexpected packet type in OctreePacketProcessor.processPacket() :", packetType);
         }
 
         // WEBRTC TODO: Address further C++ code.

--- a/src/domain/octree/OctreePacketProcessor.ts
+++ b/src/domain/octree/OctreePacketProcessor.ts
@@ -1,0 +1,85 @@
+//
+//  OctreePacketProcessor.ts
+//
+//  Created by Julien Merzoug on 18 May 2022.
+//  Copyright 2022 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import PacketType from "../networking/udt/PacketHeaders";
+import ContextManager from "../shared/ContextManager";
+import Node from "../networking/Node";
+import NodeList from "../networking/NodeList";
+import PacketReceiver from "../networking/PacketReceiver";
+import ReceivedMessage from "../networking/ReceivedMessage";
+
+
+/*@devdoc
+ *  The <code>OctreePacketProcessor</code> class handles processing of incoming voxel packets.
+ *  <p>C++: <code>class OctreePacketProcessor : public ReceivedPacketProcessor</code></p>
+ *
+ *  @class OctreePacketProcessor
+ *  @property {string} contextItemType="OctreePacketProcessor" - The type name for use with the {@link ContextManager}.
+ *
+ *  @param {number} contextID - The {@link ContextManager} context ID.
+ */
+// WEBRTC TODO:  Extend ReceivedPacketProcessor.
+class OctreePacketProcessor {
+    // C++  OctreePacketProcessor.cpp
+
+
+    static readonly contextItemType = "OctreePacketProcessor";
+
+
+    // Context
+    #_nodeList;
+    #_packetReceiver;
+
+    constructor(contextID: number) {
+
+        // Context
+        this.#_nodeList = ContextManager.get(contextID, NodeList) as NodeList;
+        this.#_packetReceiver = this.#_nodeList.getPacketReceiver();
+
+        const octreePackets = [
+            PacketType.OctreeStats,
+            PacketType.EntityData,
+            PacketType.EntityErase,
+            PacketType.EntityQueryInitialResultsComplete
+        ];
+
+        // C++ packetReceiver.registerDirectListenerForTypes() is used but in TypeScript we can use the non-direct variant of
+        // the method.
+        // Also, processPacket() is called directly unlike in the C++ where received packets are pushed to a queue
+        // via OctreePacketProcessor::handleOctreePacket().
+        this.#_packetReceiver.registerListenerForTypes(octreePackets,
+            PacketReceiver.makeSourcedListenerReference(this.#processPacket));
+    }
+
+    // Listener
+    // eslint-disable-next-line
+    // @ts-ignore
+    #processPacket = (message: ReceivedMessage, sendingNode: Node | null): void => {// eslint-disable-line
+        // C++ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode)
+
+        const packetType = message.getType();
+
+        switch (packetType) {
+            case PacketType.OctreeStats:
+            case PacketType.EntityData:
+            case PacketType.EntityErase:
+            case PacketType.EntityQueryInitialResultsComplete:
+                console.warn("OctreePacketProcessor: Packet type %d not processed: ", packetType);
+                break;
+            default:
+                console.error("ERROR - Unknown packet type in processPacket() :", packetType);
+        }
+
+        // WEBRTC TODO: Address further C++ code.
+
+    };
+}
+
+export default OctreePacketProcessor;

--- a/src/domain/octree/OctreeQuery.ts
+++ b/src/domain/octree/OctreeQuery.ts
@@ -28,7 +28,7 @@ enum OctreeQueryFlags {
 
 
 /*@devdoc
- *  The <code>OctreeQuery</code> class
+ *  The <code>OctreeQuery</code> class implements an octree Vircadia protocol query.
  *  <p>C++: <code>class OctreeQuery : public NodeData</code></p>
  *  @class OctreeQuery
  *  @param {boolean} randomizeConnectionID - <code>true</code> to use a random number for the initial connection ID,

--- a/src/domain/shared/ContextManager.ts
+++ b/src/domain/shared/ContextManager.ts
@@ -91,7 +91,7 @@ const ContextManager = new class {
      *  @function ContextManager.set
      *  @param {number} contextID - The ID of the context.
      *  @param {ContextManager.DependencyType} dependencyType - The type of the new object to create and add. The new object is
-     *      created using using <code>new()</code>.
+     *      created using <code>new()</code>.
      *  @param {...any} dependencyParams - Optional parameters to use when creating the new object.
      *  @throws Throws an error of the context ID is invalid or an object of the specified type already exists in the context.
      */

--- a/tests/domain/networking/PacketReceiver.unit.test.js
+++ b/tests/domain/networking/PacketReceiver.unit.test.js
@@ -114,6 +114,26 @@ describe("PacketReceiver - unit tests", () => {
         packetReceiver.handleVerifiedPacket(packet);
     });
 
+    test("Can register a sourced listener for types", () => {
+        function fn() {
+            //
+        }
+
+        // Create.
+        const packetReceiver = ContextManager.get(contextID, NodeList).getPacketReceiver();
+        const registerListener = jest.spyOn(packetReceiver, "registerListener").mockImplementation(() => { /* no-op */ });
+
+        const listenerReference = PacketReceiver.makeSourcedListenerReference(fn);
+        expect(listenerReference.listener).toBe(fn);
+        expect(listenerReference.sourced).toBe(true);
+        expect(listenerReference.deliverPending).toBe(false);
+
+        // Register.
+        packetReceiver.registerListenerForTypes([PacketType.Ping, PacketType.KillAvatar], listenerReference);
+        expect(registerListener).toHaveBeenCalledTimes(2);
+
+        registerListener.mockRestore();
+    });
 
     log.mockReset();
 });

--- a/tests/domain/octree/OctreePacketProcessor.unit.test.js
+++ b/tests/domain/octree/OctreePacketProcessor.unit.test.js
@@ -1,0 +1,27 @@
+//
+//  OctreePacketProcessor.unit.test.js
+//
+//  Created by Julien Merzoug on 18 May 2022.
+//  Copyright 2022 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import AddressManager from "../../../src/domain/networking/AddressManager";
+import ContextManager from "../../../src/domain/shared/ContextManager";
+import NodeList from "../../../src/domain/networking/NodeList";
+import OctreePacketProcessor from "../../../src/domain/octree/OctreePacketProcessor";
+
+
+describe("OctreePacketProcessor - unit tests", () => {
+
+    test("The OctreePacketProcessor can be obtained from the ContextManager", () => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, OctreePacketProcessor, contextID);
+        const octreePacketProcessor = ContextManager.get(contextID, OctreePacketProcessor);
+        expect(octreePacketProcessor instanceof OctreePacketProcessor).toBe(true);
+    });
+});


### PR DESCRIPTION
Receive packets from the entity server

- [x] Add a class `OctreePacketProcessor` with a method `processPacket()`.
- [x] Implement just enough to confirm packets are received from the entity server.  