### PR TITLE
Add MyAvatar scale and targetScale

### DIFF
--- a/example/interface.css
+++ b/example/interface.css
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 1 Aug 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/example/interface.html
+++ b/example/interface.html
@@ -113,6 +113,12 @@
         </div>
 
         <div class="row">
+            <span>Scale:</span>
+            <input id="avatarScale" type="number" class="narrow" />
+            with target of <input id="avatarTargetScale" type="number" class="narrow" readonly="readonly" />
+        </div>
+
+        <div class="row">
             <span>Position:</span>
             x: <input id="avatarMixerPosX" type="number" class="narrow" />
             y: <input id="avatarMixerPosY" type="number" class="narrow" />

--- a/example/interface.js
+++ b/example/interface.js
@@ -272,6 +272,8 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
         const myAvatarDisplayName = document.getElementById("myAvatarDisplayName");
         const myAvatarSessionDisplayName = document.getElementById("myAvatarSessionDisplayName");
         const myAvatarSkeletonModelURL = document.getElementById("myAvatarSkeletonModelURL");
+        const avatarScale = document.getElementById("avatarScale");
+        const avatarTargetScale = document.getElementById("avatarTargetScale");
         const avatarMixerPosX = document.getElementById("avatarMixerPosX");
         const avatarMixerPosY = document.getElementById("avatarMixerPosY");
         const avatarMixerPosZ = document.getElementById("avatarMixerPosZ");
@@ -296,6 +298,23 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
         });
         myAvatarSkeletonModelURL.addEventListener("blur", () => {
             avatarMixer.myAvatar.skeletonModelURL = myAvatarSkeletonModelURL.value;
+        });
+
+        avatarScale.value = avatarMixer.myAvatar.scale.toFixed(1);
+        avatarMixer.myAvatar.scaleChanged.connect((scale) => {
+            avatarScale.value = scale.toFixed(1);
+        });
+        avatarScale.addEventListener("blur", () => {
+            avatarMixer.myAvatar.scale = parseFloat(avatarScale.value);
+            const VERIFY_TIMEOUT = 500;
+            setTimeout(() => {
+                // In case the scale value was rejected. Or do in game loop.
+                avatarScale.value = avatarMixer.myAvatar.scale.toFixed(1);
+            }, VERIFY_TIMEOUT);
+        });
+        avatarTargetScale.value = avatarMixer.myAvatar.targetScale.toFixed(1);
+        avatarMixer.myAvatar.targetScaleChanged.connect((scale) => {
+            avatarTargetScale.value = scale.toFixed(1);
         });
 
         const avatarPosition = avatarMixer.myAvatar.position;

--- a/src/AvatarMixer.ts
+++ b/src/AvatarMixer.ts
@@ -5,6 +5,7 @@
 //
 //  Created by David Rowe on 24 Aug 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/src/domain/avatar-renderer/Avatar.ts
+++ b/src/domain/avatar-renderer/Avatar.ts
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 28 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -10,7 +11,6 @@
 
 import AvatarData from "../avatars/AvatarData";
 import AvatarConstants from "../shared/AvatarConstants";
-import SignalEmitter, { Signal } from "../shared/SignalEmitter";
 
 
 /*@devdoc
@@ -21,26 +21,28 @@ import SignalEmitter, { Signal } from "../shared/SignalEmitter";
  *  @extends SpatiallyNestable
  *  @param {number} contextID - The {@link ContextManager} context ID.
  *
- *  @property {string|null} displayName - The avatar's display name.
+ *  @comment Avatar properties.
+ *  @comment None.
+ *
+ *  @comment AvatarData properties - copied from AvatarData; do NOT edit here.
  *  @property {Signal<AvatarData~displayNameChanged>} displayNameChanged - Triggered when the avatar's display name changes.
- *  @property {string|null} sessionDisplayName - The avatar's session display name as assigned by the avatar mixer. It is based
- *      on the display name and is unique among all avatars present in the domain. <em>Read-only.</em>
  *  @property {Signal<AvatarData~sessionDisplayNameChanged>} sessionDisplayNameChanged - Triggered when the avatar's session
  *      display name changes.
- *  @property {string|null} skeletonModelURL - The URL of the avatar's FST, glTF, or FBX model file.
  *  @property {Signal<AvatarData~skeletonModelURLChanged>} skeletonModelURLChanged - Triggered when the avatar's skeleton model
  *      URL changes.
- *  @property {vec3} position - The position of the avatar in the domain.
- *  @property {quat} orientation - The orientation of the avatar in the domain.
+ *  @property {Signal<AvatarData~skeletonChanged>} skeletonChanged - Triggered when the avatar's skeleton changes.
+ *  @property {Signal<AvatarData~targetScaleChanged>} targetScaleChanged - Triggered when the avatar's target scale changes.
  *
- *  @property {Signal<Avatar~targetScaleChanged>} targetScaleChanged - Triggered when the avatar's target scale changes.
+ *  @comment SpatiallyNestable properties - copied from SpatiallyNestable; do NOT edit here.
+ *  @comment None.
  */
 class Avatar extends AvatarData {
     // C++  class Avatar : public AvatarData, public ModelProvider, public MetaModelPayload
 
     #_initialized = false;
 
-    #_targetScaleChanged = new SignalEmitter();
+    // The targetScaleChanged signal is implemented in AvatarData because that is where the targetScale member is.
+    // #_targetScaleChanged = new SignalEmitter();
 
 
     constructor(contextID: number) {  // eslint-disable-line @typescript-eslint/no-useless-constructor
@@ -48,16 +50,6 @@ class Avatar extends AvatarData {
         super(contextID);
 
         // WEBRTC TODO: Address further C++ code.
-    }
-
-
-    /*@sdkdoc
-     *  Triggered when the avatar's target scale changes.
-     *  @callback Avatar~targetScaleChanged
-     *  @param {number} targetScale - The new target avatar scale.
-     */
-    get targetScaleChanged(): Signal {
-        return this.#_targetScaleChanged.signal();
     }
 
 
@@ -101,26 +93,51 @@ class Avatar extends AvatarData {
 
     // JSDoc is in AvatarData.
     override setTargetScale(targetScale: number): void {
+        // C++  void setTargetScale(float targetScale) override
         const newValue = Math.max(AvatarConstants.MIN_AVATAR_SCALE, Math.min(targetScale, AvatarConstants.MAX_AVATAR_SCALE));
         if (this._targetScale !== newValue) {
             this._targetScale = newValue;
             this._scaleChanged = Date.now();
             this._avatarScaleChanged = this._scaleChanged;
 
-            // WEBRTC TODO: Address further C++ - _isAnimatingScale.
+            // The Web SDK isn't concerned with animating the avatar's scale changes.
+
             // WEBRTC TODO: Address further C++ - _multiSphereShapes.
 
-            this.#_targetScaleChanged.emit(this._targetScale);
+            this._targetScaleChanged.emit(this._targetScale);
         }
     }
 
-
+    /*@devdoc
+     *  Possibly update the session display name from network data: do update in the <code>Avatar</code> class and derived.
+     *  @param {string|null} sessionDisplayName The session display name.
+     */
     // eslint-disable-next-line class-methods-use-this
-    protected override maybeUpdateSessionDisplayNameFromTransport(sessionDisplayName: string | null): void {
+    override maybeUpdateSessionDisplayNameFromTransport(sessionDisplayName: string | null): void {
         // C++  void maybeUpdateSessionDisplayNameFromTransport(const QString& sessionDisplayName)
         this._sessionDisplayName = sessionDisplayName;
         this._sessionDisplayNameChanged.emit();
-        // WEBRTC TODO: Address further C++ code - sessionDisplayNameChanged signal.
+    }
+
+    /*@devdoc
+     *  Gets whether the avatar's eye height is able to be measured.
+     *  @returns {boolean} <code>true</code> in the <code>Avatar</code> class.
+     */
+    override canMeasureEyeHeight(): boolean {  // eslint-disable-line class-methods-use-this
+        // C++  virtual bool canMeasureEyeHeight() const override
+        return true;
+    }
+
+    /*@devdoc
+     *  Gets the unscaled avatar eye height.
+     *  @returns {number} The unscaled avatar eye height.
+     */
+    override getUnscaledEyeHeight(): number {
+        // C++  float getUnscaledEyeHeight() const
+
+        // WEBRTC TODO: Address further C++ - return _unscaledEyeHeightCache.get() instead of the super value.
+
+        return super.getUnscaledEyeHeight();
     }
 
 }

--- a/src/domain/avatar-renderer/Avatar.ts
+++ b/src/domain/avatar-renderer/Avatar.ts
@@ -9,6 +9,8 @@
 //
 
 import AvatarData from "../avatars/AvatarData";
+import AvatarConstants from "../shared/AvatarConstants";
+import SignalEmitter, { Signal } from "../shared/SignalEmitter";
 
 
 /*@devdoc
@@ -30,11 +32,15 @@ import AvatarData from "../avatars/AvatarData";
  *      URL changes.
  *  @property {vec3} position - The position of the avatar in the domain.
  *  @property {quat} orientation - The orientation of the avatar in the domain.
+ *
+ *  @property {Signal<Avatar~targetScaleChanged>} targetScaleChanged - Triggered when the avatar's target scale changes.
  */
 class Avatar extends AvatarData {
     // C++  class Avatar : public AvatarData, public ModelProvider, public MetaModelPayload
 
     #_initialized = false;
+
+    #_targetScaleChanged = new SignalEmitter();
 
 
     constructor(contextID: number) {  // eslint-disable-line @typescript-eslint/no-useless-constructor
@@ -42,6 +48,16 @@ class Avatar extends AvatarData {
         super(contextID);
 
         // WEBRTC TODO: Address further C++ code.
+    }
+
+
+    /*@sdkdoc
+     *  Triggered when the avatar's target scale changes.
+     *  @callback Avatar~targetScaleChanged
+     *  @param {number} targetScale - The new target avatar scale.
+     */
+    get targetScaleChanged(): Signal {
+        return this.#_targetScaleChanged.signal();
     }
 
 
@@ -81,6 +97,21 @@ class Avatar extends AvatarData {
         super.setSkeletonModelURL(skeletonModelURL);
 
         // WEBRTC TODO: Address further C++ code.
+    }
+
+    // JSDoc is in AvatarData.
+    override setTargetScale(targetScale: number): void {
+        const newValue = Math.max(AvatarConstants.MIN_AVATAR_SCALE, Math.min(targetScale, AvatarConstants.MAX_AVATAR_SCALE));
+        if (this._targetScale !== newValue) {
+            this._targetScale = newValue;
+            this._scaleChanged = Date.now();
+            this._avatarScaleChanged = this._scaleChanged;
+
+            // WEBRTC TODO: Address further C++ - _isAnimatingScale.
+            // WEBRTC TODO: Address further C++ - _multiSphereShapes.
+
+            this.#_targetScaleChanged.emit(this._targetScale);
+        }
     }
 
 

--- a/src/domain/avatar-renderer/ScriptAvatar.ts
+++ b/src/domain/avatar-renderer/ScriptAvatar.ts
@@ -49,6 +49,8 @@ import Vec3, { vec3 } from "../shared/Vec3";
  *  @property {number} scale - The scale of the avatar. This includes any limits on permissible values imposed by the domain.
  *      <code>0.0</code> if the avatar doesn't exist.
  *      <em>Read-only.</em>
+ *  @property {Signal<ScriptAvatar~scaleChanged>} scaleChanged - Triggered when the avatar's scale changes. This can be
+ *      due to the user changing the scale of their avatar or the domain limiting the scale of their avatar.
  *  @property {vec3} position - The position of the avatar in the domain. {@link Vec3|Vec3.ZERO} if the avatar doesn't exist.
  *      <em>Read-only.</em>
  *  @property {quat} orientation - The orientation of the avatar in the domain. {@link Quat|Quat.IDENTITY} if the avatar doesn't
@@ -97,7 +99,7 @@ class ScriptAvatar {
         if (this.#_avatarData) {
             const avatar = this.#_avatarData.deref();
             if (avatar) {
-                return avatar.displayName !== null ? avatar.displayName : "";
+                return avatar.getDisplayName() ?? "";
             }
         }
         return "";
@@ -123,7 +125,7 @@ class ScriptAvatar {
         if (this.#_avatarData) {
             const avatar = this.#_avatarData.deref();
             if (avatar) {
-                return avatar.sessionDisplayName !== null ? avatar.sessionDisplayName : "";
+                return avatar.getSessionDisplayName() ?? "";
             }
         }
         return "";
@@ -148,8 +150,8 @@ class ScriptAvatar {
         // C++  QString ScriptAvatarData::getSkeletonModelURLFromScript()
         if (this.#_avatarData) {
             const avatar = this.#_avatarData.deref();
-            if (avatar && avatar.skeletonModelURL !== null) {
-                return avatar.skeletonModelURL;
+            if (avatar) {
+                return avatar.getSkeletonModelURL() ?? "";
             }
         }
         return "";
@@ -174,8 +176,8 @@ class ScriptAvatar {
         // C++  No direct equivalent.
         if (this.#_avatarData) {
             const avatar = this.#_avatarData.deref();
-            if (avatar && avatar.skeleton !== null) {
-                return avatar.skeleton;
+            if (avatar) {
+                return avatar.getSkeletonData() ?? [];
             }
         }
         return [];
@@ -204,6 +206,21 @@ class ScriptAvatar {
             }
         }
         return 0;
+    }
+
+    /*@sdkdoc
+     *  Triggered when the avatar's scale changes.
+     *  @callback ScriptAvatar~scaleChanged
+     *  @param {number} The new avatar scale.
+     */
+    get scaleChanged(): Signal {
+        if (this.#_avatarData) {
+            const avatar = this.#_avatarData.deref();
+            if (avatar) {
+                return avatar.targetScaleChanged;
+            }
+        }
+        return new SignalEmitter().signal();
     }
 
     get position(): vec3 {

--- a/src/domain/avatar/MyAvatar.ts
+++ b/src/domain/avatar/MyAvatar.ts
@@ -34,6 +34,8 @@ import Uuid from "../shared/Uuid";
  *      URL changes.
  *  @property {vec3} position - The position of the avatar in the domain.
  *  @property {quat} orientation - The orientation of the avatar in the domain.
+ *
+ *  @property {Signal<Avatar~targetScaleChanged>} targetScaleChanged - Triggered when the avatar's target scale changes.
  */
 class MyAvatar extends Avatar {
     // C++  class MyAvatar : public Avatar

--- a/src/domain/avatars/ClientTraitsHandler.ts
+++ b/src/domain/avatars/ClientTraitsHandler.ts
@@ -157,8 +157,8 @@ class ClientTraitsHandler {
             // WEBRTC TODO: Send other trait types.
             const packetList = PacketScribe.SetAvatarTraits.write({
                 currentTraitVersion: this.#_currentTraitVersion,
-                skeletonModelURL: this.#_owningAvatar.skeletonModelURL !== null ? this.#_owningAvatar.skeletonModelURL : "",
-                skeletonData: this.#_owningAvatar.skeleton !== null ? this.#_owningAvatar.skeleton : [],
+                skeletonModelURL: this.#_owningAvatar.getSkeletonModelURL() ?? "",
+                skeletonData: this.#_owningAvatar.getSkeletonData() ?? [],
                 traitStatuses: traitStatusCopy,
                 initialSend
             });

--- a/src/domain/interfaces/AvatarListInterface.ts
+++ b/src/domain/interfaces/AvatarListInterface.ts
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 31 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/src/domain/interfaces/MyAvatarInterface.ts
+++ b/src/domain/interfaces/MyAvatarInterface.ts
@@ -10,6 +10,7 @@
 //
 
 import { SkeletonJoint } from "../avatars/AvatarTraits";
+import AvatarConstants from "../shared/AvatarConstants";
 import ContextManager from "../shared/ContextManager";
 import Quat, { quat } from "../shared/Quat";
 import { Signal } from "../shared/SignalEmitter";
@@ -33,6 +34,11 @@ import AvatarManager from "../AvatarManager";
  *  @property {string} skeletonModelURL - The URL of the avatar's FST, glTF, or FBX model file.
  *  @property {Signal<MyAvatarInterface~skeletonModelURLChanged>} skeletonModelURLChanged - Triggered when the avatar's skeleton
  *      model URL changes.
+ *  @property {number} targetScale=1.0 - The target scale of the avatar, <code>0.005</code> &mdash; <code>1000.0</code>. Unlike
+ *      <code>scale</code>, this value is not limited by the domain's settings.
+ *  @property {Signal<MyAvatarInterface~targetScaleChanged>} targetScaleChanged - Triggered when the avatar's target scale
+ *      changes.
+ *  @property {number} targetScale=1.0 - The target scale of the avatar, <code>0.005</code> &mdash; <code>1000.0</code>. This
  *  @property {vec3} position - The position of the avatar in the domain.
  *  @property {quat} orientation - The orientation of the avatar in the domain.
  *  @property {SkeletonJoint[]|null} skeleton - Information on the avatar's skeleton. <code>null</code> if the avatar doesn't
@@ -149,6 +155,31 @@ class MyAvatarInterface {
      */
     get skeletonChanged(): Signal {
         return this.#_avatarManager.getMyAvatar().skeletonChanged;
+    }
+
+    get targetScale(): number {
+        return this.#_avatarManager.getMyAvatar().getTargetScale();
+    }
+
+    set targetScale(targetScale: number) {
+        if (typeof targetScale !== "number") {
+            console.error("[AvatarMixer] [MyAvatar] Tried to set invalid targetScale!", JSON.stringify(targetScale));
+            return;
+        }
+        if (targetScale < AvatarConstants.MIN_AVATAR_SCALE || targetScale > AvatarConstants.MAX_AVATAR_SCALE) {
+            console.warn("[AvatarMixer][MyAvatar] Tried to set an out of range targetScale value.", targetScale);
+        }
+        this.#_avatarManager.getMyAvatar().setTargetScale(Math.max(AvatarConstants.MIN_AVATAR_SCALE,
+            Math.min(targetScale, AvatarConstants.MAX_AVATAR_SCALE)));
+    }
+
+    /*@sdkdoc
+     *  Triggered when the avatar's target scale changes.
+     *  @callback MyAvatarInterface~targetScaleChanged
+     *  @param {number} targetScale - The new target avatar scale.
+     */
+    get targetScaleChanged(): Signal {
+        return this.#_avatarManager.getMyAvatar().targetScaleChanged;
     }
 
     get position(): vec3 {

--- a/src/domain/interfaces/MyAvatarInterface.ts
+++ b/src/domain/interfaces/MyAvatarInterface.ts
@@ -34,11 +34,15 @@ import AvatarManager from "../AvatarManager";
  *  @property {string} skeletonModelURL - The URL of the avatar's FST, glTF, or FBX model file.
  *  @property {Signal<MyAvatarInterface~skeletonModelURLChanged>} skeletonModelURLChanged - Triggered when the avatar's skeleton
  *      model URL changes.
+ *  @property {number} scale=1.0 - The scale of the avatar. The value can be set to a target value in the range
+ *      <code>0.005</code> &mdash; <code>1000.0</code>, however when the scale value is fetched, it may temporarily be limited
+ *      by the current domain's settings.
+ *  @property {Signal<MyAvatarInterface~scaleChanged>} scaleChanged - Triggered when the avatar's scale changes. This can be
+ *      due to the user changing the scale of their avatar or the domain limiting the scale of their avatar.
  *  @property {number} targetScale=1.0 - The target scale of the avatar, <code>0.005</code> &mdash; <code>1000.0</code>. Unlike
  *      <code>scale</code>, this value is not limited by the domain's settings.
  *  @property {Signal<MyAvatarInterface~targetScaleChanged>} targetScaleChanged - Triggered when the avatar's target scale
  *      changes.
- *  @property {number} targetScale=1.0 - The target scale of the avatar, <code>0.005</code> &mdash; <code>1000.0</code>. This
  *  @property {vec3} position - The position of the avatar in the domain.
  *  @property {quat} orientation - The orientation of the avatar in the domain.
  *  @property {SkeletonJoint[]|null} skeleton - Information on the avatar's skeleton. <code>null</code> if the avatar doesn't
@@ -58,8 +62,7 @@ class MyAvatarInterface {
 
 
     get displayName(): string {
-        const displayName = this.#_avatarManager.getMyAvatar().displayName;
-        return displayName !== null ? displayName : "";
+        return this.#_avatarManager.getMyAvatar().getDisplayName() ?? "";
     }
 
     set displayName(displayName: string) {
@@ -67,7 +70,7 @@ class MyAvatarInterface {
             console.error("[AvatarMixer] [MyAvatar] Tried to set invalid display name!", JSON.stringify(displayName));
             return;
         }
-        this.#_avatarManager.getMyAvatar().displayName = displayName;
+        this.#_avatarManager.getMyAvatar().setDisplayName(displayName);
     }
 
     /*@sdkdoc
@@ -79,8 +82,7 @@ class MyAvatarInterface {
     }
 
     get sessionDisplayName(): string {
-        const sessionDisplayName = this.#_avatarManager.getMyAvatar().sessionDisplayName;
-        return sessionDisplayName !== null ? sessionDisplayName : "";
+        return this.#_avatarManager.getMyAvatar().getSessionDisplayName() ?? "";
     }
 
     /*@sdkdoc
@@ -92,8 +94,7 @@ class MyAvatarInterface {
     }
 
     get skeletonModelURL(): string {
-        const skeletonModelURL = this.#_avatarManager.getMyAvatar().skeletonModelURL;
-        return skeletonModelURL !== null ? skeletonModelURL : "";
+        return this.#_avatarManager.getMyAvatar().getSkeletonModelURL() ?? "";
     }
 
     set skeletonModelURL(skeletonModelURL: string) {
@@ -102,7 +103,7 @@ class MyAvatarInterface {
                 JSON.stringify(skeletonModelURL));
             return;
         }
-        this.#_avatarManager.getMyAvatar().skeletonModelURL = skeletonModelURL;
+        this.#_avatarManager.getMyAvatar().setSkeletonModelURL(skeletonModelURL);
     }
 
     /*@sdkdoc
@@ -114,7 +115,7 @@ class MyAvatarInterface {
     }
 
     get skeleton(): SkeletonJoint[] | null {
-        return this.#_avatarManager.getMyAvatar().skeleton;
+        return this.#_avatarManager.getMyAvatar().getSkeletonData();
     }
 
     set skeleton(skeleton: SkeletonJoint[] | null) {
@@ -144,9 +145,9 @@ class MyAvatarInterface {
                 skeletonString.slice(0, MAX_STRING_LENGTH) + (skeletonString.length > MAX_STRING_LENGTH ? "..." : ""));
             return;
         }
-        this.#_avatarManager.getMyAvatar().skeleton = skeleton !== null
+        this.#_avatarManager.getMyAvatar().setSkeletonData(skeleton !== null
             ? JSON.parse(JSON.stringify(skeleton)) as SkeletonJoint[]  // Make a copy.
-            : null;
+            : null);
     }
 
     /*@sdkdoc
@@ -155,6 +156,33 @@ class MyAvatarInterface {
      */
     get skeletonChanged(): Signal {
         return this.#_avatarManager.getMyAvatar().skeletonChanged;
+    }
+
+    get scale(): number {
+        // C++  MyAvatar::scale
+        return this.#_avatarManager.getMyAvatar().getDomainLimitedScale();
+    }
+
+    set scale(scale: number) {
+        // C++  MyAvatar::scale
+        if (typeof scale !== "number") {
+            console.error("[AvatarMixer] [MyAvatar] Tried to set invalid scale!", JSON.stringify(scale));
+            return;
+        }
+        if (scale < AvatarConstants.MIN_AVATAR_SCALE || scale > AvatarConstants.MAX_AVATAR_SCALE) {
+            console.warn("[AvatarMixer] [MyAvatar] Tried to set an out of range targetScale value.", scale);
+        }
+        this.#_avatarManager.getMyAvatar().setTargetScale(Math.max(AvatarConstants.MIN_AVATAR_SCALE,
+            Math.min(scale, AvatarConstants.MAX_AVATAR_SCALE)));
+    }
+
+    /*@sdkdoc
+     *  Triggered when the avatar's scale changes.
+     *  @callback MyAvatarInterface~scaleChanged
+     *  @param {number} scale - The avatar's scale.
+     */
+    get scaleChanged(): Signal {
+        return this.#_avatarManager.getMyAvatar().scaleChanged;
     }
 
     get targetScale(): number {
@@ -167,7 +195,7 @@ class MyAvatarInterface {
             return;
         }
         if (targetScale < AvatarConstants.MIN_AVATAR_SCALE || targetScale > AvatarConstants.MAX_AVATAR_SCALE) {
-            console.warn("[AvatarMixer][MyAvatar] Tried to set an out of range targetScale value.", targetScale);
+            console.warn("[AvatarMixer] [MyAvatar] Tried to set an out of range targetScale value.", targetScale);
         }
         this.#_avatarManager.getMyAvatar().setTargetScale(Math.max(AvatarConstants.MIN_AVATAR_SCALE,
             Math.min(targetScale, AvatarConstants.MAX_AVATAR_SCALE)));
@@ -176,14 +204,14 @@ class MyAvatarInterface {
     /*@sdkdoc
      *  Triggered when the avatar's target scale changes.
      *  @callback MyAvatarInterface~targetScaleChanged
-     *  @param {number} targetScale - The new target avatar scale.
+     *  @param {number} targetScale - The avatar's target scale.
      */
     get targetScaleChanged(): Signal {
         return this.#_avatarManager.getMyAvatar().targetScaleChanged;
     }
 
     get position(): vec3 {
-        return this.#_avatarManager.getMyAvatar().position;
+        return this.#_avatarManager.getMyAvatar().getWorldPosition();
     }
 
     set position(position: vec3) {
@@ -191,11 +219,11 @@ class MyAvatarInterface {
             console.error("[AvatarMixer] [MyAvatar] Tried to set an invalid position value!", JSON.stringify(position));
             return;
         }
-        this.#_avatarManager.getMyAvatar().position = position;
+        this.#_avatarManager.getMyAvatar().setWorldPosition(position);
     }
 
     get orientation(): quat {
-        return this.#_avatarManager.getMyAvatar().orientation;
+        return this.#_avatarManager.getMyAvatar().getWorldOrientation();
     }
 
     set orientation(orientation: quat) {
@@ -203,7 +231,7 @@ class MyAvatarInterface {
             console.error("[AvatarMixer] [MyAvatar] Tried to set an invalid orientation value!", JSON.stringify(orientation));
             return;
         }
-        this.#_avatarManager.getMyAvatar().orientation = orientation;
+        this.#_avatarManager.getMyAvatar().setWorldOrientation(orientation);
     }
 
 }

--- a/src/domain/networking/packets/AvatarData.ts
+++ b/src/domain/networking/packets/AvatarData.ts
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 29 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -36,7 +37,8 @@ type AvatarDataDetails = {
 
     // Avatar data.
     globalPosition: vec3 | undefined,
-    localOrientation: quat | undefined
+    localOrientation: quat | undefined,
+    avatarScale: number | undefined
 };
 
 
@@ -56,8 +58,13 @@ const AvatarData = new class {
      *  @property {boolean} distanceAdjust
      *  @property {vec3} viewerPosition
      *
-     *  @property {vec3|undefined} globalPosition - The avatar's position in the domain.
-     *  @property {quat|undefined} localOrientation - The avatar's orientation.
+     *  @property {vec3|undefined} globalPosition - The avatar's position in the domain.<br />
+     *      Should be <code>undefined</code> if not known, otherwise it should always be sent.
+     *  @property {quat|undefined} localOrientation - The avatar's orientation.<br />
+     *      Should be <code>undefined</code> if not known or the value hasn't changed since the last time the packet was sent.
+     *  @property {number|undefined} avatarScale - The target scale of the avatar. The target scale is the desired scale of the
+     *      avatar without any restrictions on permissible scale values imposed by the domain.<br />
+     *      Should be <code>undefined</code> if not known or the value hasn't changed since the last time the packet was sent.
      */
 
 
@@ -119,10 +126,10 @@ const AvatarData = new class {
 
             if (sendStatus.itemFlags === 0) {
                 // New avatar...
-                const hasAvatarGlobalPosition = info.globalPosition !== undefined;
-                const hasAvatarOrientation = info.localOrientation !== undefined;
+                const hasAvatarGlobalPosition = info.globalPosition !== undefined;  // Should always be sent.
+                let hasAvatarOrientation = false;
                 const hasAvatarBoundingBox = false;
-                const hasAvatarScale = false;
+                let hasAvatarScale = false;
                 const hasLookAtPosition = false;
                 const hasAudioLoudness = false;
                 const hasSensorToWorldMatrix = false;
@@ -142,10 +149,16 @@ const AvatarData = new class {
                 if (sendPALMinimum) {
                     // hasAudioLoudness = true;
                 } else {
+                    // The C++ code is included here - commented out - so that the native client logic can be seen. In the Web
+                    // SDK the "ChangedSince()" logic is included in the caller to AvatarData.write().
+                    //
                     // WEBRTC TODO: Address further C++ code - Further avatar properties.
-                    // hasAvatarOrientation = sendAll || info.avatarData.rotationChangedSince(info.lastSentTime);
+                    //
+                    // hasAvatarOrientation = sendAll || rotationChangedSince(lastSentTime);
+                    hasAvatarOrientation = info.localOrientation !== undefined;
                     // hasAvatarBoundingBox = sendAll || avatarBoundingBoxChangedSince(lastSentTime);
                     // hasAvatarScale = sendAll || avatarScaleChangedSince(lastSentTime);
+                    hasAvatarScale = info.avatarScale !== undefined;
                     // hasLookAtPosition = sendAll || lookAtPositionChangedSince(lastSentTime);
                     // hasAudioLoudness = sendAll || audioLoudnessChangedSince(lastSentTime);
                     // hasSensorToWorldMatrix = sendAll || sensorToWorldMatrixChangedSince(lastSentTime);
@@ -228,7 +241,6 @@ const AvatarData = new class {
 
             // WEBRTC TODO: Address further C++ code - PACKET_HAS_AVATAR_BOUNDING_BOX.
 
-            // WEBRTC TODO: Address further C++ code - PACKET_HAS_AVATAR_ORIENTATION.
             if (avatarSpace(AvatarDataPacket.PACKET_HAS_AVATAR_ORIENTATION, 6)) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 GLMHelpers.packOrientationQuatToSixBytes(data, dataPosition, info.localOrientation!);
@@ -236,7 +248,13 @@ const AvatarData = new class {
                 // WEBRTC TODO: Address further C++ code - Outbound data rate.
             }
 
-            // WEBRTC TODO: Address further C++ code - PACKET_HAS_AVATAR_SCALE.
+            if (avatarSpace(AvatarDataPacket.PACKET_HAS_AVATAR_SCALE, 2)) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                GLMHelpers.packFloatRatioToTwoByte(data, dataPosition, info.avatarScale!);
+                dataPosition += 2;
+                // WEBRTC TODO: Address further C++ code - Outbound data rate.
+            }
+
             // WEBRTC TODO: Address further C++ code - PACKET_HAS_LOOK_AT_POSITION.
             // WEBRTC TODO: Address further C++ code - PACKET_HAS_AUDIO_LOUDNESS.
             // WEBRTC TODO: Address further C++ code - PACKET_HAS_SENSOR_TO_WORLD_MATRIX.

--- a/src/domain/networking/packets/AvatarData.ts
+++ b/src/domain/networking/packets/AvatarData.ts
@@ -149,8 +149,8 @@ const AvatarData = new class {
                 if (sendPALMinimum) {
                     // hasAudioLoudness = true;
                 } else {
-                    // The C++ code is included here - commented out - so that the native client logic can be seen. In the Web
-                    // SDK the "ChangedSince()" logic is included in the caller to AvatarData.write().
+                    // The C++ code is included here - commented out - so that the native client logic can be seen.
+                    // In the Web SDK, the "ChangedSince()" logic is included in the caller to AvatarData.write().
                     //
                     // WEBRTC TODO: Address further C++ code - Further avatar properties.
                     //

--- a/src/domain/networking/packets/BulkAvatarData.ts
+++ b/src/domain/networking/packets/BulkAvatarData.ts
@@ -55,7 +55,7 @@ const BulkAvatarData = new class {
      *      <code>undefined</code> if not included in the packet.
      *  @property {number|undefined} avatarScale - The avatar's scale.
      *      <code>undefined</code> if not included in the packet.
-     *  @property {Array<quat|null>|undefined}} jointRotations - The joint rotations relative to avatar space (i.e., not
+     *  @property {Array<quat|null>|undefined} jointRotations - The joint rotations relative to avatar space (i.e., not
      *      relative to parent bones). If a rotation is <code>null</code> then the rotation of the avatar's default pose should
      *      be used.
      *      <code>undefined</code> if not included in the packet.

--- a/src/domain/networking/udt/SendQueue.ts
+++ b/src/domain/networking/udt/SendQueue.ts
@@ -292,7 +292,7 @@ class SendQueue {
     */
 
     /*@devdoc
-     *  Triggered when the queue has been inactive to 5s.
+     *  Triggered when the queue has been inactive for 5s.
      *  @function SendQueue.queueInactive
      *  @returns {Signal}
      */
@@ -302,7 +302,7 @@ class SendQueue {
 
     /*@devdoc
      *  Triggered when sending on the queue has timed out.
-     *  @function SendQueue.queueInactive
+     *  @function SendQueue.timeout
      *  @returns {Signal}
      */
     get timeout(): Signal {

--- a/src/domain/shared/AvatarConstants.ts
+++ b/src/domain/shared/AvatarConstants.ts
@@ -15,6 +15,9 @@
  *  @class AvatarConstants
  *
  *  @property {number} DEFAULT_AVATAR_HEIGHT=1.755 - The default avatar height, in meters.
+ *  @property {number} DEFAULT_AVATAR_EYE_TO_TOP_OF_HEAD=0.11 - The default vertical distance between the avatar's eyes to the
+ *      top of head, in meters.
+ *  @property {number} DEFAULT_AVATAR_EYE_HEIGHT= 1.645 - The default height of the avatar's eyes.
  *  @property {number} MAX_AVATAR_HEIGHT= 1755.0 - The absolute maximum avatar height.
  *  @property {number} MIN_AVATAR_HEIGHT=0.008775 - The absolute minimum avatar height.
  *
@@ -27,6 +30,10 @@ class AvatarConstants {
     /* eslint-disable @typescript-eslint/no-magic-numbers */
 
     static readonly DEFAULT_AVATAR_HEIGHT = 1.755;  // meters
+    static readonly DEFAULT_AVATAR_EYE_TO_TOP_OF_HEAD = 0.11; // meters
+
+    static readonly DEFAULT_AVATAR_EYE_HEIGHT = AvatarConstants.DEFAULT_AVATAR_HEIGHT
+        - AvatarConstants.DEFAULT_AVATAR_EYE_TO_TOP_OF_HEAD;
 
     static readonly MAX_AVATAR_HEIGHT = 1000.0 * AvatarConstants.DEFAULT_AVATAR_HEIGHT;
     static readonly MIN_AVATAR_HEIGHT = 0.005 * AvatarConstants.DEFAULT_AVATAR_HEIGHT;

--- a/src/domain/shared/SpatiallyNestable.ts
+++ b/src/domain/shared/SpatiallyNestable.ts
@@ -42,6 +42,9 @@ enum NestableType {
 class SpatiallyNestable {
     // C++  class SpatiallyNestable
 
+    protected _scaleChanged = Date.now();
+
+
     #_nestableType;
     #_id;
 
@@ -185,7 +188,6 @@ class SpatiallyNestable {
 
     }
 
-
     /*@devdoc
      *  Gets the local orientation of the entity or avatar.
      *  @returns {quat} The local orientation of the entity or avatar.
@@ -214,13 +216,25 @@ class SpatiallyNestable {
 
     }
 
+
+    /*@devdoc
+     *  Gets whether the entity or avatar's scale has changed since a given time.
+     *  @param {number} time - The time in milliseconds elapsed since 1 Jan 1970 00:00:00 UTC.
+     *  @returns {boolean} <code>true</code> if the scale has changed since the given time, <code>false</code> if it
+     *      hasn't.
+     */
+    protected scaleChangedSince(time: number): boolean {
+        // C++  bool scaleChangedSince(quint64 time)
+        return this._scaleChanged > time;
+    }
+
     /*@devdoc
      *  Gets whether the entity or avatar's translation has changed since a given time.
      *  @param {number} time - The time in milliseconds elapsed since 1 Jan 1970 00:00:00 UTC.
      *  @returns {boolean} <code>true</code> if the translation has changed since the given time, <code>false</code> if it
      *      hasn't.
      */
-    translationChangedSince(time: number): boolean {
+    protected translationChangedSince(time: number): boolean {
         // C++  bool tranlationChangedSince(quint64 time)
         return this.#_translationChanged > time;
     }
@@ -231,7 +245,7 @@ class SpatiallyNestable {
      *  @returns {boolean} <code>true</code> if the rotation has changed since the given time, <code>false</code> if it
      *      hasn't.
      */
-    rotationChangedSince(time: number): boolean {
+    protected rotationChangedSince(time: number): boolean {
         // C++  bool rotationChangedSince(quint64 time)
         return this.#_rotationChanged > time;
     }

--- a/src/domain/shared/SpatiallyNestable.ts
+++ b/src/domain/shared/SpatiallyNestable.ts
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 28 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -137,7 +138,7 @@ class SpatiallyNestable {
 
     /*@devdoc
      *  Gets the world orientation of the entity or avatar.
-     *  @returns {vec3} The world orientation of the entity or avatar.
+     *  @returns {quat} The world orientation of the entity or avatar.
      */
     getWorldOrientation(): quat {
         // C++  glm::vec3 getWorldPosition()
@@ -200,6 +201,10 @@ class SpatiallyNestable {
         return this.#_worldOrientation;
     }
 
+    /*@devdoc
+     *  Sets the local orientation of the entity or avatar.
+     *  @param {quat} orientation - The local orientation of the entity or avatar.
+     */
     setLocalOrientation(orientation: quat): void {
         // C++  void setLocalOrientation(const glm::quat& orientation)
 

--- a/tests/domain/avatar-renderer/Avatar.unit.test.js
+++ b/tests/domain/avatar-renderer/Avatar.unit.test.js
@@ -30,4 +30,29 @@ describe("Avatar - unit tests", () => {
         expect(true).toBe(true);
     });
 
+    test("Can set and get the target avatar scale", (done) => {
+        const avatar = new Avatar(contextID);
+        let scaleChangeCount = 0;
+        let scaleChangeTotal = 0.0;
+        avatar.targetScaleChanged.connect((scale) => {
+            scaleChangeCount += 1;
+            scaleChangeTotal += scale;
+        });
+
+        expect(avatar.getTargetScale()).toEqual(1.0);  // Default.
+        avatar.setTargetScale(1.2);
+        expect(avatar.getTargetScale()).toEqual(1.2);
+        avatar.setTargetScale(2000.0);
+        avatar.setTargetScale(2000.0);  // Call again to check that signal isn't triggered again.
+        expect(avatar.getTargetScale()).toEqual(1000.0);  // MAX_AVATAR_SCALE
+        avatar.setTargetScale(0.00001);
+        expect(avatar.getTargetScale()).toEqual(0.005);  // MIN_AVATAR_SCALE
+
+        setTimeout(() => {  // Let targetScaleChanged() events process.
+            expect(scaleChangeCount).toEqual(3);
+            expect(scaleChangeTotal).toEqual(1001.205);
+            done();
+        }, 10);
+    });
+
 });

--- a/tests/domain/avatar-renderer/Avatar.unit.test.js
+++ b/tests/domain/avatar-renderer/Avatar.unit.test.js
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 28 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -13,6 +14,7 @@
 import Avatar from "../../../src/domain/avatar-renderer/Avatar";
 import AddressManager from "../../../src/domain/networking/AddressManager";
 import NodeList from "../../../src/domain/networking/NodeList";
+import AvatarConstants from "../../../src/domain/shared/AvatarConstants";
 import ContextManager from "../../../src/domain/shared/ContextManager";
 
 
@@ -51,6 +53,38 @@ describe("Avatar - unit tests", () => {
         setTimeout(() => {  // Let targetScaleChanged() events process.
             expect(scaleChangeCount).toEqual(3);
             expect(scaleChangeTotal).toEqual(1001.205);
+            done();
+        }, 10);
+    });
+
+    test("Can limit the avatar height per the domain", (done) => {
+        const avatar = new Avatar(contextID);
+        let scaleChangedCount = 0;
+        avatar.targetScaleChanged.connect(() => {
+            scaleChangedCount += 1;
+        });
+
+        expect(avatar.getTargetScale()).toEqual(1.0);
+        expect(avatar.getDomainLimitedScale()).toBe(1.0);
+
+        avatar.setDomainMaximumHeight(AvatarConstants.DEFAULT_AVATAR_HEIGHT / 2.0);
+        expect(avatar.getDomainLimitedScale()).toBeCloseTo(0.5, 2);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMaximumHeight(AvatarConstants.MAX_AVATAR_HEIGHT / 2);
+        expect(avatar.getDomainLimitedScale()).toBe(1.0);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMinimumHeight(AvatarConstants.DEFAULT_AVATAR_HEIGHT * 2.0);
+        expect(avatar.getDomainLimitedScale()).toBeCloseTo(2.0, 1);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMinimumHeight(AvatarConstants.MIN_AVATAR_HEIGHT * 2);
+        expect(avatar.getDomainLimitedScale()).toBe(1.0);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        setTimeout(() => {
+            expect(scaleChangedCount).toEqual(0);
             done();
         }, 10);
     });

--- a/tests/domain/avatar-renderer/ScriptAvatar.unit.test.js
+++ b/tests/domain/avatar-renderer/ScriptAvatar.unit.test.js
@@ -45,6 +45,8 @@ describe("ScriptAvatar - unit tests", () => {
         // Can access signals.
         expect(typeof scriptAvatar.displayNameChanged.connect).toBe("function");
         expect(typeof scriptAvatar.displayNameChanged.disconnect).toBe("function");
+        expect(typeof scriptAvatar.scaleChanged.connect).toBe("function");
+        expect(typeof scriptAvatar.scaleChanged.disconnect).toBe("function");
         expect(typeof scriptAvatar.sessionDisplayNameChanged.connect).toBe("function");
         expect(typeof scriptAvatar.sessionDisplayNameChanged.disconnect).toBe("function");
         expect(typeof scriptAvatar.skeletonModelURLChanged.connect).toBe("function");
@@ -79,6 +81,8 @@ describe("ScriptAvatar - unit tests", () => {
         // Can access signals.
         expect(typeof scriptAvatar.displayNameChanged.connect).toBe("function");
         expect(typeof scriptAvatar.displayNameChanged.disconnect).toBe("function");
+        expect(typeof scriptAvatar.scaleChanged.connect).toBe("function");
+        expect(typeof scriptAvatar.scaleChanged.disconnect).toBe("function");
         expect(typeof scriptAvatar.sessionDisplayNameChanged.connect).toBe("function");
         expect(typeof scriptAvatar.sessionDisplayNameChanged.disconnect).toBe("function");
         expect(typeof scriptAvatar.skeletonModelURLChanged.connect).toBe("function");

--- a/tests/domain/avatar/MyAvatar.unit.test.js
+++ b/tests/domain/avatar/MyAvatar.unit.test.js
@@ -1,0 +1,89 @@
+//
+//  MyAvatar.unit.test.js
+//
+//  Created by David Rowe on 18 Jun 2022.
+//  Copyright 2022 Vircadia contributors.
+//  Copyright 2022 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+
+import MyAvatar from "../../../src/domain/avatar/MyAvatar";
+import AddressManager from "../../../src/domain/networking/AddressManager";
+import NodeList from "../../../src/domain/networking/NodeList";
+import AvatarConstants from "../../../src/domain/shared/AvatarConstants";
+import ContextManager from "../../../src/domain/shared/ContextManager";
+
+
+describe("MyAvatar - unit tests", () => {
+
+    const contextID = ContextManager.createContext();
+    ContextManager.set(contextID, AddressManager);
+    ContextManager.set(contextID, NodeList, contextID);
+
+    test("Can limit the avatar height per the domain", (done) => {
+        const avatar = new MyAvatar(contextID);
+        let targetScaleChangedCount = 0;
+        avatar.targetScaleChanged.connect(() => {
+            targetScaleChangedCount += 1;
+        });
+        // Note: It's not valid to test avatar.scaleChanged signals because it is not triggered when using
+        // setDomainMaximumHeight() and setDomainMinimumHeight().
+
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMaximumHeight(AvatarConstants.DEFAULT_AVATAR_HEIGHT / 2.0);
+        expect(avatar.getDomainLimitedScale()).toBeCloseTo(0.5, 2);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMaximumHeight(AvatarConstants.MAX_AVATAR_HEIGHT / 2);
+        expect(avatar.getDomainLimitedScale()).toBe(1.0);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMinimumHeight(AvatarConstants.DEFAULT_AVATAR_HEIGHT * 2.0);
+        expect(avatar.getDomainLimitedScale()).toBeCloseTo(2.0, 1);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        avatar.setDomainMinimumHeight(AvatarConstants.MIN_AVATAR_HEIGHT / 2);
+        expect(avatar.getDomainLimitedScale()).toBe(1.0);
+        expect(avatar.getTargetScale()).toEqual(1.0);
+
+        setTimeout(() => {
+            expect(targetScaleChangedCount).toEqual(0);
+            done();
+        }, 10);
+    });
+
+    test("The scale change is signaled when the scale is changed", (done) => {
+        const avatar = new MyAvatar(contextID);
+        let targetScaleChangedCount = 0;
+        let scaleChangedCount = 0;
+        avatar.targetScaleChanged.connect(() => {
+            targetScaleChangedCount += 1;
+        });
+        avatar.scaleChanged.connect(() => {
+            scaleChangedCount += 1;
+        });
+
+        expect(avatar.getDomainLimitedScale()).toEqual(1.0);
+        avatar.setTargetScale(2.0);
+        avatar.setTargetScale(2.0);  // Repeat to check that signal isn't fired twice.
+        expect(avatar.getDomainLimitedScale()).toEqual(2.0);
+        avatar.setTargetScale(0.5);
+        avatar.setTargetScale(0.5);
+        expect(avatar.getDomainLimitedScale()).toEqual(0.5);
+        avatar.setTargetScale(1.0);
+        avatar.setTargetScale(1.0);
+        expect(avatar.getDomainLimitedScale()).toEqual(1.0);
+
+        setTimeout(() => {
+            expect(targetScaleChangedCount).toEqual(3);
+            expect(scaleChangedCount).toEqual(3);
+            done();
+        }, 10);
+    });
+
+});

--- a/tests/domain/avatars/AvatarData.unit.test.js
+++ b/tests/domain/avatars/AvatarData.unit.test.js
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 28 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -15,6 +16,7 @@ AudioWorkletsMock.mock();
 import AvatarData from "../../../src/domain/avatars/AvatarData";
 import AddressManager from "../../../src/domain/networking/AddressManager";
 import NodeList from "../../../src/domain/networking/NodeList";
+import AvatarConstants from "../../../src/domain/shared/AvatarConstants";
 import ContextManager from "../../../src/domain/shared/ContextManager";
 import { Uuid } from "../../../src/Vircadia";
 
@@ -45,15 +47,61 @@ describe("AvatarData - unit tests", () => {
         expect(avatarData.getIdentityDataChanged()).toBe(true);
     });
 
-    test("Can set and get the target avatar scale", () => {
+    test("Can set and get the target avatar scale", (done) => {
         const avatarData = new AvatarData(contextID);
+        let scaleChangedCount = 0;
+        avatarData.targetScaleChanged.connect(() => {
+            scaleChangedCount += 1;
+        });
+
         expect(avatarData.getTargetScale()).toEqual(1.0);
         avatarData.setTargetScale(1.2);
         expect(avatarData.getTargetScale()).toEqual(1.2);
         avatarData.setTargetScale(2000.0);
         expect(avatarData.getTargetScale()).toEqual(1000.0);  // MAX_AVATAR_SCALE
+        avatarData.setTargetScale(1000.0);  // No "scale changed" signal.
+        expect(avatarData.getTargetScale()).toEqual(1000.0);
         avatarData.setTargetScale(0.00001);
         expect(avatarData.getTargetScale()).toEqual(0.005);  // MIN_AVATAR_SCALE
+        avatarData.setTargetScale(0.005);
+        expect(avatarData.getTargetScale()).toEqual(0.005);  // No "scale changed" signal.
+
+        setTimeout(() => {
+            expect(scaleChangedCount).toEqual(3);
+            done();
+        }, 10);
+    });
+
+    test("Cannot limit the avatar height per the domain", (done) => {
+        // This because at the AvatarData class level the target scale cannot be changed.
+        const avatarData = new AvatarData(contextID);
+        let scaleChangedCount = 0;
+        avatarData.targetScaleChanged.connect(() => {
+            scaleChangedCount += 1;
+        });
+
+        expect(avatarData.getTargetScale()).toEqual(1.0);
+
+        avatarData.setDomainMaximumHeight(AvatarConstants.DEFAULT_AVATAR_HEIGHT / 2.0);
+        expect(avatarData.getDomainLimitedScale()).toBe(1.0);
+        expect(avatarData.getTargetScale()).toEqual(1.0);
+
+        avatarData.setDomainMaximumHeight(AvatarConstants.MAX_AVATAR_HEIGHT / 2);
+        expect(avatarData.getDomainLimitedScale()).toBe(1.0);
+        expect(avatarData.getTargetScale()).toEqual(1.0);
+
+        avatarData.setDomainMinimumHeight(AvatarConstants.DEFAULT_AVATAR_HEIGHT * 2.0);
+        expect(avatarData.getDomainLimitedScale()).toBe(1.0);
+        expect(avatarData.getTargetScale()).toEqual(1.0);
+
+        avatarData.setDomainMinimumHeight(AvatarConstants.MIN_AVATAR_HEIGHT / 2);
+        expect(avatarData.getDomainLimitedScale()).toBe(1.0);
+        expect(avatarData.getTargetScale()).toEqual(1.0);
+
+        setTimeout(() => {
+            expect(scaleChangedCount).toEqual(0);
+            done();
+        }, 10);
     });
 
 });

--- a/tests/domain/avatars/AvatarData.unit.test.js
+++ b/tests/domain/avatars/AvatarData.unit.test.js
@@ -45,7 +45,7 @@ describe("AvatarData - unit tests", () => {
         expect(avatarData.getIdentityDataChanged()).toBe(true);
     });
 
-    test("Can set and get the avatar scale", () => {
+    test("Can set and get the target avatar scale", () => {
         const avatarData = new AvatarData(contextID);
         expect(avatarData.getTargetScale()).toEqual(1.0);
         avatarData.setTargetScale(1.2);

--- a/tests/domain/interfaces/MyAvatarInterface.unit.test.js
+++ b/tests/domain/interfaces/MyAvatarInterface.unit.test.js
@@ -59,7 +59,7 @@ describe("MyAvatarInterface - unit tests", () => {
 
         expect(myAvatarInterface.targetScale).toBe(1.0);  // Default value.
         expect(errorCount).toBe(0);
-        myAvatarInterface.targetScale = "2.0";
+        myAvatarInterface.targetScale = "2.0";  // String value instead of number.
         expect(errorCount).toBe(1);
         expect(myAvatarInterface.targetScale).toBe(1.0);
 
@@ -72,7 +72,7 @@ describe("MyAvatarInterface - unit tests", () => {
         myAvatarInterface.targetScale = 0.001;
         expect(myAvatarInterface.targetScale).toBe(0.005);  // Clamped value.
 
-        setTimeout(() => {  // Let targetScaleChanged() events process.
+        setTimeout(() => {  // Let events process.
             expect(scaleChangeCount).toEqual(3);
             expect(scaleChangeTotal).toEqual(1001.205);
             done();

--- a/tests/domain/interfaces/MyAvatarInterface.unit.test.js
+++ b/tests/domain/interfaces/MyAvatarInterface.unit.test.js
@@ -11,9 +11,10 @@
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import AvatarManager from "../../../src/domain/AvatarManager";
 import MyAvatarInterface from "../../../src/domain/interfaces/MyAvatarInterface";
+import AvatarConstants from "../../../src/domain/shared/AvatarConstants";
 import ContextManager from "../../../src/domain/shared/ContextManager";
+import AvatarManager from "../../../src/domain/AvatarManager";
 import DomainServer from "../../../src/DomainServer";
 
 
@@ -32,6 +33,8 @@ describe("MyAvatarInterface - unit tests", () => {
         expect(typeof myAvatarInterface.skeletonModelURLChanged.disconnect).toBe("function");
         expect(typeof myAvatarInterface.skeletonChanged.connect).toBe("function");
         expect(typeof myAvatarInterface.skeletonChanged.disconnect).toBe("function");
+        expect(typeof myAvatarInterface.scaleChanged.connect).toBe("function");
+        expect(typeof myAvatarInterface.scaleChanged.disconnect).toBe("function");
         expect(typeof myAvatarInterface.targetScaleChanged.connect).toBe("function");
         expect(typeof myAvatarInterface.targetScaleChanged.disconnect).toBe("function");
     });
@@ -77,6 +80,96 @@ describe("MyAvatarInterface - unit tests", () => {
 
         warn.mockReset();
         error.mockReset();
+    });
+
+    test("Avatar scale can be limited by the domain", (done) => {
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
+        let errorCount = 0;
+        const error = jest.spyOn(console, "error").mockImplementation(() => {
+            errorCount += 1;
+        });
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => { /* no-op */ });  // Ignore out-of-range warnings.
+        const log = jest.spyOn(console, "log").mockImplementation(() => { /* no-op */ });  // Ignore domain requirements info.
+
+        const domainServer = new DomainServer();
+        const contextID = domainServer.contextID;
+        ContextManager.set(contextID, AvatarManager, contextID);
+        const myAvatarInterface = new MyAvatarInterface(contextID);
+        let targetScaleChangeCount = 0;
+        let targetScaleChangeTotal = 0.0;
+        let scaleChangeCount = 0;
+        let scaleChangeTotal = 0.0;
+        myAvatarInterface.targetScaleChanged.connect((scale) => {
+            targetScaleChangeCount += 1;
+            targetScaleChangeTotal += scale;
+        });
+        myAvatarInterface.scaleChanged.connect((scale) => {
+            scaleChangeCount += 1;
+            scaleChangeTotal += scale;
+        });
+
+        expect(myAvatarInterface.scale).toBe(1.0);  // Default value.
+        expect(errorCount).toBe(0);
+        myAvatarInterface.scale = "2.0";  // String value instead of number.
+        expect(errorCount).toBe(1);
+        expect(myAvatarInterface.scale).toBe(1.0);
+
+        const avatarManager = ContextManager.get(contextID, AvatarManager);
+        const myAvatar = avatarManager.getMyAvatar();
+
+        myAvatar.restrictScaleFromDomainSettings({
+            avatars: {
+                "min_avatar_height": AvatarConstants.MIN_AVATAR_HEIGHT,
+                "max_avatar_height": AvatarConstants.DEFAULT_AVATAR_HEIGHT / 2.0
+            }
+        });
+        expect(myAvatarInterface.scale).toBeCloseTo(0.5, 2);
+        expect(myAvatarInterface.targetScale).toEqual(1.0);
+
+        myAvatar.restrictScaleFromDomainSettings({
+            avatars: {
+                "min_avatar_height": AvatarConstants.MIN_AVATAR_HEIGHT,
+                "max_avatar_height": AvatarConstants.MAX_AVATAR_HEIGHT / 2.0
+            }
+        });
+        expect(myAvatarInterface.scale).toBe(1.0);
+        expect(myAvatarInterface.targetScale).toEqual(1.0);
+
+        myAvatar.restrictScaleFromDomainSettings({
+            avatars: {
+                "min_avatar_height": AvatarConstants.DEFAULT_AVATAR_HEIGHT * 2.0,
+                "max_avatar_height": AvatarConstants.MAX_AVATAR_HEIGHT
+            }
+        });
+        expect(myAvatarInterface.scale).toBeCloseTo(2.0, 1);
+        expect(myAvatarInterface.targetScale).toEqual(1.0);
+
+        myAvatar.restrictScaleFromDomainSettings({
+            avatars: {
+                "min_avatar_height": AvatarConstants.MIN_AVATAR_HEIGHT * 2.0,
+                "max_avatar_height": AvatarConstants.MAX_AVATAR_HEIGHT
+            }
+        });
+        expect(myAvatarInterface.scale).toBe(1.0);
+        expect(myAvatarInterface.targetScale).toEqual(1.0);
+
+        expect(errorCount).toBe(1);
+
+        setTimeout(() => {  // Let events process.
+            expect(targetScaleChangeCount).toEqual(0);
+            expect(targetScaleChangeTotal).toEqual(0);
+            expect(scaleChangeCount).toBeCloseTo(4.0, 1);
+            expect(scaleChangeTotal).toBeCloseTo(4.5, 1);
+            done();
+        }, 10);
+
+        log.mockReset();
+        warn.mockReset();
+        error.mockReset();
+
+        /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
     });
 
 });

--- a/tests/domain/networking/packets/AvatarData.unit.test.js
+++ b/tests/domain/networking/packets/AvatarData.unit.test.js
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 29 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -56,6 +57,31 @@ describe("AvatarData - unit tests", () => {
             viewerPosition: { x: 0, y: 0, z: 0 },
             globalPosition: { x: -10, y: 100, z: 20 },
             localOrientation: { x: 0, y: 0.866025, z: 0, w: -0.5 }
+        });
+        expect(packet instanceof NLPacket).toBe(true);
+        expect(packet.getType()).toBe(PacketType.AvatarData);
+        const packetSize = packet.getDataSize();
+        expect(packetSize).toBe(packet.getMessageData().dataPosition);
+        expect(packetSize).toBeGreaterThan(0);
+        expect(packetSize).toBeLessThan(UDT.MAX_PACKET_SIZE);
+
+        expect(packetSize).toBe(EXPECTED_PACKET.length / 2);
+        expect(buffer2hex(packet.getMessageData().buffer.slice(0, packetSize))).toBe(EXPECTED_PACKET);
+    });
+
+    test("Can write an AvatarData packet - avatar scale", () => {
+        // eslint-disable-next-line max-len
+        const EXPECTED_PACKET = "000000000636000000000000000000000000000000000000c1000d009a9999bfc3f5a83f33338b41bfff3fff10cb4e12";
+        const packet = AvatarData.write({
+            sequenceNumber: 193,
+            dataDetail: 3,
+            lastSentTime: Date.now(),
+            dropFaceTracking: false,
+            distanceAdjust: false,
+            viewerPosition: { x: 0, y: 0, z: 0 },
+            globalPosition: { x: -1.2, y: 1.32, z: 17.4 },
+            localOrientation: { x: 0, y: 0.85322, z: 0, w: 0.52156 },
+            avatarScale: 1.43012
         });
         expect(packet instanceof NLPacket).toBe(true);
         expect(packet.getType()).toBe(PacketType.AvatarData);

--- a/tests/domain/shared/AvatarConstants.unit.test.js
+++ b/tests/domain/shared/AvatarConstants.unit.test.js
@@ -1,0 +1,28 @@
+//
+//  AvatarConstants.unit.test.js
+//
+//  Created by David Rowe on 9 Jun 2022.
+//  Copyright 2022 Vircadia contributors.
+//  Copyright 2022 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import AvatarConstants from "../../../src/domain/shared/AvatarConstants";
+
+
+describe("AvataConstants - unit tests", () => {
+
+    test("Can access avatar constants", () => {
+        // Test a handful constants, just to make that constants can be accessed as intended.
+
+        /* eslint-disable @typescript-eslint/no-magic-numbers */
+
+        expect(AvatarConstants.DEFAULT_AVATAR_HEIGHT).toEqual(1.755);
+        expect(AvatarConstants.MIN_AVATAR_SCALE).toEqual(0.005);
+
+        /* eslint-enable @typescript-eslint/no-magic-numbers */
+    });
+
+});

--- a/tests/domain/shared/SpatiallyNestable.unit.test.js
+++ b/tests/domain/shared/SpatiallyNestable.unit.test.js
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 28 Oct 2021.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2021 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
- Send own avatar target scale to avatar mixer.
- Provide own avatar target scale in API.
- Provide domain server limited avatar scale in API.
- Simplify MyAvatar, Avatar, and AvatarData internal APIs.

Note: Domain server avatar limits are per domain server defaults until DomainSettings packet is handled - https://github.com/vircadia/vircadia-web-sdk/issues/114.