### PR TITLE
Handle droppable silent audio frames.

### DIFF
--- a/src/domain/audio-client/AudioClient.ts
+++ b/src/domain/audio-client/AudioClient.ts
@@ -66,7 +66,9 @@ class AudioClient {
 
     static readonly contextItemType = "AudioClient";
 
-    static readonly #RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES = 100;
+    // C++  RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES = 100.
+    //      Multiplied by 240 / 128 because native client has 240 samples per block whereas audio worklet has 128.
+    static readonly #RECEIVED_AUDIO_STREAM_CAPACITY_BLOCKS = 180;  // = AudioOutputProcessor.MAX_AUDIO_BUFFER_LENGTH
 
 
     static #computeLoudness(pcmData: Int16Array | null): number {
@@ -131,7 +133,7 @@ class AudioClient {
         // This field is not a MixedProcessedAudioStream in the Web SDK version of AudioClient because the features of
         // MixedProcessedAudioStream haven't been needed so far.
         this.#_receivedAudioStream = new InboundAudioStream(contextID, AudioConstants.STEREO,
-            AudioConstants.NETWORK_FRAME_SAMPLES_PER_CHANNEL, AudioClient.#RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES, -1);
+            AudioConstants.NETWORK_FRAME_SAMPLES_PER_CHANNEL, AudioClient.#RECEIVED_AUDIO_STREAM_CAPACITY_BLOCKS, -1);
 
         // C++  Application::Application()
         this.#start();

--- a/src/domain/audio/AudioConstants.ts
+++ b/src/domain/audio/AudioConstants.ts
@@ -26,6 +26,8 @@
  *
  *  @property {number} NETWORK_FRAME_SECS - <code>0.01</code> - The interval between audio network packets, in seconds.
  *  @property {number} NETWORK_FRAME_MSECS - <code>10</code> - The interval between audio network packets, in milliseconds.
+ *
+ *  @property {number} AUDIO_WORKLET_BLOCK_SIZE - <code>128</code> - The number of frames in and audio worklet audio block.
  */
 const AudioConstants = new class {
     // C++  AudioConstants
@@ -41,6 +43,8 @@ const AudioConstants = new class {
 
     readonly NETWORK_FRAME_SECS = this.NETWORK_FRAME_SAMPLES_PER_CHANNEL / this.SAMPLE_RATE;
     readonly NETWORK_FRAME_MSECS = this.NETWORK_FRAME_SECS * 1000;
+
+    readonly AUDIO_WORKLET_BLOCK_SIZE = 128;  // 128 frames of samples.
 
 }();
 

--- a/src/domain/audio/AudioOutput.ts
+++ b/src/domain/audio/AudioOutput.ts
@@ -31,8 +31,9 @@ import assert from "../shared/assert";
  *  @property {string} audioWorkletRelativePath="" - The relative path to the SDK's audio worklet JavaScript files,
  *      <code>vircadia-audio-input.js</code> and <code>vircadia-audio-output.js</code>.
  *      <p>The URLs used to load these files are reported in the log. Depending on where these files are deployed, their URLs
- *      may need to be adjusted.  If used, must start with a <code>"."</code> and end with a <code>"/"</code>.</p>
+ *      may need to be adjusted. If used, must start with a <code>"."</code> and end with a <code>"/"</code>.</p>
  *      <p><em>Write-only.</em></p>
+ *  @property {number} bufferSize - The number of bytes currently being buffered for audio output.
  */
 class AudioOutput {
     //  C++ N/A - This is a Web SDK-specific class.
@@ -55,6 +56,8 @@ class AudioOutput {
     #_outputArrayLength = this.#AUDIOWORKLETPROCESSOR_DATA_BLOCKS_SIZE;
     #_outputOffset = 0;  // The next write position.
 
+    #_outputBufferSize = 0;  // Bytes.
+
     #_audioWorkletRelativePath = "";
 
 
@@ -68,7 +71,13 @@ class AudioOutput {
     }
 
     set audioWorkletRelativePath(relativePath: string) {
+        // C++  N/A
         this.#_audioWorkletRelativePath = relativePath;
+    }
+
+    get bufferSize(): number {
+        // C++  N/A
+        return this.#_outputBufferSize;
     }
 
 
@@ -147,6 +156,18 @@ class AudioOutput {
         this.#_outputOffset = index;  // Starting point for next packet of audio.
     }
 
+    /*@devdoc
+     *  Handles the information received back from the {@link AudioOutputProcessor}.
+     *  @function AudioOutput.processAudioOutputMessage
+     *  @param {MessageEvent<number>} message - The number of blocks of audio data in the output buffer.
+     *  @returns {Slot}
+     */
+    processAudioOutputMessage = (message: MessageEvent<number>): void => {
+        // C++  N/A
+
+        this.#_outputBufferSize = message.data * this.#AUDIOWORKLETPROCESSOR_DATA_BLOCKS_SIZE;
+    };
+
 
     // Sets up the AudioContext etc.
     async #setUpAudioContext(): Promise<void> {
@@ -180,6 +201,7 @@ class AudioOutput {
             channelCountMode: "explicit"
         });
         this.#_audioWorkletPort = this.#_audioWorkletNode.port;
+        this.#_audioWorkletPort.onmessage = this.processAudioOutputMessage;
 
         // Wire up the nodes.
         this.#_oscillatorNode.connect(this.#_audioWorkletNode);

--- a/src/domain/worklets/AudioOutputProcessor.ts
+++ b/src/domain/worklets/AudioOutputProcessor.ts
@@ -30,9 +30,9 @@ class AudioOutputProcessor extends AudioWorkletProcessor {
     // Buffer blocks of audio data so that they can be played back smoothly.
     // FIXME: All these fields should be private (#s) but Firefox isn't handling transpiled code with them (Sep 2021).
     _audioBuffer: Int16Array[] = [];
-    // MAX_AUDIO_BUFFER_LENGTH = AudioClient.#RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES
-    readonly MAX_AUDIO_BUFFER_LENGTH = 100;  // The maximum number of audio blocks to buffer
-    readonly MIN_AUDIO_BUFFER_LENGTH = 50;  // The minimum number of audio blocks to have before starting to play them.
+    // MAX_AUDIO_BUFFER_LENGTH = AudioClient.#RECEIVED_AUDIO_STREAM_CAPACITY_BLOCKS
+    readonly MAX_AUDIO_BUFFER_LENGTH = 180;  // The maximum number of audio blocks to buffer
+    readonly MIN_AUDIO_BUFFER_LENGTH = 90;  // The minimum number of audio blocks to have before starting to play them.
     _isPlaying = false;  // Is playing audio blocks from the buffer.
 
 
@@ -97,6 +97,7 @@ class AudioOutputProcessor extends AudioWorkletProcessor {
         let audioBlock: Int16Array | undefined = undefined;
         if (this._isPlaying) {
             audioBlock = this._audioBuffer.shift();
+            this.port.postMessage(this._audioBuffer.length);
             if (audioBlock === undefined) {
                 // console.log("AudioOutputProcessor: Stop playing");
                 this._isPlaying = false;

--- a/src/domain/worklets/AudioOutputProcessor.ts
+++ b/src/domain/worklets/AudioOutputProcessor.ts
@@ -47,6 +47,7 @@ class AudioOutputProcessor extends AudioWorkletProcessor {
      *  Takes incoming audio blocks posted to the audio worklet's message port and queues them in a ring buffer for playing.
      *  If too many audio blocks are queued, some of the older ones are discarded.
      *  If too few audio blocks are queued, playing is paused while a minimum number of audio blocks are accumulated.
+     *  The number of audio blocks buffered is posted on the message port.
      *  @function AudioOutputProcessor.onMessage
      *  @param {MessageEvent} message - The message posted to the audio worklet, with <code>message.data</code> being an
      *      <code>Int16Array</code> of PCM audio samples, ready to play.
@@ -71,6 +72,9 @@ class AudioOutputProcessor extends AudioWorkletProcessor {
                 this._isPlaying = true;
             }
         }
+
+        // Report the number of audio blocks buffered.
+        this.port.postMessage(this._audioBuffer.length);
     };
 
 


### PR DESCRIPTION
Droppable silent audio frames are dropped instead of being played if the audio output jitter buffer contains more than the target number of audio output blocks.