### PR TITLE
Add domain entity editing functionality.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,7 +99,7 @@ module.exports = {
         "@typescript-eslint/no-magic-numbers": [
             "error",
             {
-                "ignore": [-1, 0, 1, 2, 0n, 1n],
+                "ignore": [-1, 0, 1, 2, "0n", "1n"],
                 "ignoreEnums": true,
                 "ignoreNumericLiteralTypes": true,
                 "ignoreReadonlyClassProperties": true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,7 +99,7 @@ module.exports = {
         "@typescript-eslint/no-magic-numbers": [
             "error",
             {
-                "ignore": [-1, 0, 1, 2],
+                "ignore": [-1, 0, 1, 2, 0n, 1n],
                 "ignoreEnums": true,
                 "ignoreNumericLiteralTypes": true,
                 "ignoreReadonlyClassProperties": true

--- a/example/interface.css
+++ b/example/interface.css
@@ -62,6 +62,10 @@ input {
         border: dotted 1px #d0d0d0;
     }
 
+    input:disabled {
+        color: #808080;
+    }
+
 button {
     width: 88px;
 }

--- a/example/interface.html
+++ b/example/interface.html
@@ -213,6 +213,11 @@
             <span>Can rez temp:</span>
             <input id="canRezTempStatus" type="text" readonly="readonly" class="narrow" />
         </div>
+
+        <div class="row">
+            <span>Can use private:</span>
+            <input id="canUsePrivateStatus" type="text" readonly="readonly" class="narrow" />
+        </div>
     </div>
 
     <h2>Message Mixer</h2>

--- a/example/interface.html
+++ b/example/interface.html
@@ -184,6 +184,35 @@
             <tbody>
             </tbody>
         </table>
+
+
+        <h3>Entity Editing</h3>
+
+        <div class="row">
+            <span>Add:</span>
+            <button id="addEntityButton" disabled="disabled">Add</button>
+            <input id="addedEntityID" type="text" readonly="readonly" class="medium"/>
+            <button id="editAddedEntityButton" disabled="disabled">Edit</button>
+            <button id="deleteAddedEntityButton" disabled="disabled">Delete</button>
+        </div>
+
+        <div class="row">
+            <span>Clone added:</span>
+            <button id="cloneEntityButton" disabled="disabled">Clone</button>
+            <input id="clonedEntityID" type="text" readonly="readonly" class="medium" />
+            <button id="editClonedEntityButton" disabled="disabled">Edit</button>
+            <button id="deleteClonedEntityButton" disabled="disabled">Delete</button>
+        </div>
+
+        <div class="row">
+            <span>Can rez:</span>
+            <input id="canRezStatus" type="text" readonly="readonly" class="narrow" />
+        </div>
+
+        <div class="row">
+            <span>Can rez temp:</span>
+            <input id="canRezTempStatus" type="text" readonly="readonly" class="narrow" />
+        </div>
     </div>
 
     <h2>Message Mixer</h2>

--- a/example/interface.js
+++ b/example/interface.js
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, MessageMixer, Vec3, Uuid }
+import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, MessageMixer, EntityType, Uuid, Vec3 }
     from "../dist/Vircadia.js";
 
 (function () {
@@ -639,6 +639,8 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
         const entityListBody = document.querySelector("#entityList > tbody");
         let entityIDsList = [];
 
+        const addEntityButton = document.getElementById("addEntityButton");
+        const addedEntityID = document.getElementById("addedEntityID");
         const canRezStatus = document.getElementById("canRezStatus");
         const canRezTempStatus = document.getElementById("canRezTempStatus");
         const canUsePrivateStatus = document.getElementById("canUsePrivateStatus");
@@ -726,8 +728,16 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
 
         // Entity Editing
 
+        addEntityButton.addEventListener("click", () => {
+            const entityID = entityServer.addEntity({
+                entityType: EntityType.Shape
+            });
+            addedEntityID.value = entityID.stringify();
+        });
+
         const onCanRezChanged = (canRez) => {
             canRezStatus.value = canRez;
+            addEntityButton.disabled = !entityServer.canRez;
         };
         entityServer.canRezChanged.connect(onCanRezChanged);
         onCanRezChanged(entityServer.canRez);

--- a/example/interface.js
+++ b/example/interface.js
@@ -639,6 +639,10 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
         const entityListBody = document.querySelector("#entityList > tbody");
         let entityIDsList = [];
 
+        const canRezStatus = document.getElementById("canRezStatus");
+        const canRezTempStatus = document.getElementById("canRezTempStatus");
+        const canUsePrivateStatus = document.getElementById("canUsePrivateStatus");
+
 
         // Status
 
@@ -646,16 +650,21 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
 
         function onStateChanged(state) {
             statusText.value = EntityServer.stateToString(state);
-            if (state === EntityServer.UNAVAILABLE || state === EntityServer.DISCONNECTED) {
+            const isConnected = state === EntityServer.CONNECTED;
+            if (!isConnected) {
                 while (entityListBody.hasChildNodes()) {
                     entityListBody.removeChild(entityListBody.firstChild);
                 }
                 entityIDsList = [];
                 entitiesCount.value = 0;
             }
+
+            canRezStatus.disabled = !isConnected;
+            canRezTempStatus.disabled = !isConnected;
+            canUsePrivateStatus.disabled = !isConnected;
         }
-        onStateChanged(entityServer.state);
         entityServer.onStateChanged = onStateChanged;
+        onStateChanged(entityServer.state);
 
 
         // Entity List
@@ -713,6 +722,27 @@ import { Vircadia, DomainServer, Camera, AudioMixer, AvatarMixer, EntityServer, 
             entitiesCount.value = entityIDsList.length;
         }
         entityServer.entityData.connect(onEntityData);
+
+
+        // Entity Editing
+
+        const onCanRezChanged = (canRez) => {
+            canRezStatus.value = canRez;
+        };
+        entityServer.canRezChanged.connect(onCanRezChanged);
+        onCanRezChanged(entityServer.canRez);
+
+        const onCanRezTempChanged = (canRezTemp) => {
+            canRezTempStatus.value = canRezTemp;
+        };
+        entityServer.canRezTempChanged.connect(onCanRezTempChanged);
+        onCanRezTempChanged(entityServer.canRezTemp);
+
+        const onCanGetAndSetPrivateUserDataChanged = (canGetAndSetPrivateUserData) => {
+            canUsePrivateStatus.value = canGetAndSetPrivateUserData;
+        };
+        entityServer.canGetAndSetPrivateUserDataChanged.connect(onCanGetAndSetPrivateUserDataChanged);
+        onCanGetAndSetPrivateUserDataChanged(entityServer.canGetAndSetPrivateUserData);
 
 
         // Game Loop

--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -323,6 +323,8 @@ class EntityServer extends AssignmentClient {
             return new Uuid();
         }
 
+        // Invalid properties are checked by when they are written to the packet.
+
         // WEBRTC TODO: Queue edit requests if not connected.
         if (this.state !== EntityServer.CONNECTED) {
             console.warn("[EntityServer] Could not send edit message because not connected.");

--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -13,6 +13,7 @@ import { EntityHostType } from "./domain/entities/EntityHostType";
 import { EntityType } from "./domain/entities/EntityTypes";
 import { EntityProperties } from "./domain/networking/packets/EntityData";
 import PacketScribe from "./domain/networking/packets/PacketScribe";
+import PacketType from "./domain/networking/udt/PacketHeaders";
 import Node from "./domain/networking/Node";
 import NodeList from "./domain/networking/NodeList";
 import NodeType, { NodeTypeValue } from "./domain/networking/NodeType";
@@ -263,8 +264,12 @@ class EntityServer extends AssignmentClient {
                 console.error("[EntityServer] addEntity() called with invalid entity hostType!");
                 return new Uuid(Uuid.NULL);
             }
-            if (hostType !== EntityHostType.DOMAIN) {
-                console.error("[EntityServer] addEntity() called with unsupported entity hostType!");
+            if (hostType === EntityHostType.AVATAR) {
+                console.error("[EntityServer] addEntity() for avatar entities not implemented!");
+                return new Uuid(Uuid.NULL);
+            }
+            if (hostType === EntityHostType.LOCAL) {
+                console.error("[EntityServer] addEntity() for local entities not implemented!");
                 return new Uuid(Uuid.NULL);
             }
         }
@@ -308,14 +313,54 @@ class EntityServer extends AssignmentClient {
         }
     }
 
-    // @ts-ignore
-    #addEntityInternal(properties: EntityProperties, hostType: EntityHostType): Uuid {
+    #addEntityInternal(properties: EntityProperties, entityHostType: EntityHostType): Uuid {
         // C++  QUuid EntityScriptingInterface::addEntityInternal(const EntityItemProperties& properties,
         //          entity::HostType entityHostType)
 
+        // WEBRTC TODO: Address further C++ code - activity tracking.
+
+        // WEBRTC TODO: Address further C++ code - avatar entities and local entities.
+        if (entityHostType === EntityHostType.AVATAR) {
+            console.error("[EntityServer] addEntity() for avatar entities not implemented!");
+            return new Uuid(Uuid.NULL);
+        }
+        if (entityHostType === EntityHostType.LOCAL) {
+            console.error("[EntityServer] addEntity() for local entities not implemented!");
+            return new Uuid(Uuid.NULL);
+        }
+
+        // WEBRTC TODO: Address further C++ code - avatar entities.
+
+        const propertiesWithSimID = JSON.parse(JSON.stringify(properties)) as EntityProperties;
+
+        // WEBRTC TODO: Address further C++ code - avatar entities and local entities.
+        // propertiesWithSimID.entityHostType = entityHostType;
+
+        propertiesWithSimID.created = BigInt(Date.now());
+
+        const sessionID = this.#_nodeList.getSessionUUID();
+        propertiesWithSimID.lastEditedBy = sessionID;
+
+        // Don't use native client's "script semantics" for properties, use the server's.
+
+        // Don't track whether the dimensions have been initialized, this is the client's responsibility.
+
+        // WEBRTC TODO: Address synchronizing grab properties?
+
+        // The SDK doesn't maintain a local entity tree so just create an entity ID.
+        const id = Uuid.createUuid();
+
+        this.#queueEntityMessage(PacketType.EntityAdd, id, propertiesWithSimID);
+        return id;
+    }
+
+    // @ts-ignore
+    #queueEntityMessage(packetType: PacketType, entityID: Uuid, properties: EntityItemProperties): void {
+        // C++  void EntityScriptingInterface::queueEntityMessage(PacketType packetType, EntityItemID entityID,
+        //          const EntityItemProperties& properties)
+
         // TODO: Implement.
 
-        return Uuid.createUuid();
     }
 
 

--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -153,6 +153,9 @@ class EntityServer extends AssignmentClient {
             this.#_canGetAndSetPrivateUserDataChanged.emit(canGetAndSetPrivateUserData);
         });
 
+        // C++  OctreeScriptingInterface::OctreeScriptingInterface(OctreeEditPacketSender* packetSender = nullptr)
+        // Nothing to do here.
+
         // C++  Application::Application()
         this.#_nodeList.nodeActivated.connect(this.#nodeActivated);
         this.#_nodeList.nodeKilled.connect(this.#nodeKilled);

--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -250,37 +250,60 @@ class EntityServer extends AssignmentClient {
 
         if (typeof properties !== "object") {
             console.error("[EntityServer] addEntity() called with invalid entity properties!");
-            return new Uuid(Uuid.NULL);
+            return new Uuid();
         }
 
         if (typeof properties.entityType !== "number" || properties.entityType <= EntityType.Unknown
                 || properties.entityType >= EntityType.NUM_TYPES) {
             console.error("[EntityServer] addEntity() called with invalid entity type!");
-            return new Uuid(Uuid.NULL);
+            return new Uuid();
         }
 
         if (typeof hostType !== "undefined") {
             if (typeof hostType !== "number" || hostType < HostType.DOMAIN || hostType > HostType.LOCAL) {
                 console.error("[EntityServer] addEntity() called with invalid entity hostType!");
-                return new Uuid(Uuid.NULL);
+                return new Uuid();
             }
             if (hostType === HostType.AVATAR) {
                 console.error("[EntityServer] addEntity() for avatar entities not implemented!");
-                return new Uuid(Uuid.NULL);
+                return new Uuid();
             }
             if (hostType === HostType.LOCAL) {
                 console.error("[EntityServer] addEntity() for local entities not implemented!");
-                return new Uuid(Uuid.NULL);
+                return new Uuid();
             }
         }
 
         if ([EntityType.Line, EntityType.PolyLine, EntityType.PolyVox, EntityType.Grid, EntityType.Gizmo]
             .includes(properties.entityType)) {
             console.error("[EntityServer] addEntity() called with unsupported entity type!", properties.entityType);
-            return new Uuid(Uuid.NULL);
+            return new Uuid();
         }
 
         return this.#addEntityInternal(properties, hostType ?? HostType.DOMAIN);
+    }
+
+    /*@sdkdoc
+     *  Edits an entity, changing one or more of its property values.
+     *  @param {Uuid} entityID - The ID of the entity to edit.
+     *  @param {Entities.EntityProperties} properties - The new property values.
+     *  @returns {Uuid} The ID of the entity if an edit request was successfully sent to the server, or
+     *      {@link Uuid(1)|Uuid.NULL} if no entity edit request was sent.
+     */
+    editEntity(entityID: Uuid, properties: EntityProperties): Uuid {
+        // C++  QUuid EntityScriptingInterface::editEntity(const QUuid& entityID, const EntityItemProperties& properties)
+
+        if (!(entityID instanceof Uuid)) {
+            console.error("[EntityServer] editEntity() called with invalid entity ID!");
+            return new Uuid();
+        }
+
+        if (typeof properties !== "object") {
+            console.error("[EntityServer] editEntity() called with invalid entity properties!");
+            return new Uuid();
+        }
+
+        return this.#editEntityInternal(entityID, properties);
     }
 
 

--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import { EntityHostType } from "./domain/entities/EntityHostType";
+import { HostType } from "./domain/entities/EntityItem";
 import { EntityType } from "./domain/entities/EntityTypes";
 import { EntityProperties } from "./domain/networking/packets/EntityData";
 import PacketScribe from "./domain/networking/packets/PacketScribe";
@@ -241,10 +241,10 @@ class EntityServer extends AssignmentClient {
     /*@sdkdoc
      *  Adds a new entity to the entity server.
      *  @param {EntityProperties} properties - The properties of the entity to add.
-     *  @param {EntityHostType} [hostType=EntityHostType.DOMAIN] - Where to host the entity.
+     *  @param {HostType} [hostType=HostType.DOMAIN] - Where to host the entity.
      *  @returns {Uuid} The ID of the new entity if added, or {@link Uuid(1)|Uuid.NULL} if no entity added.
      */
-    addEntity(properties: EntityProperties, hostType?: EntityHostType): Uuid {
+    addEntity(properties: EntityProperties, hostType?: HostType): Uuid {
         // C++  QUuid EntityScriptingInterface::addEntity(const EntityItemProperties& properties,
         //          const QString& entityHostTypeString)
 
@@ -260,15 +260,15 @@ class EntityServer extends AssignmentClient {
         }
 
         if (typeof hostType !== "undefined") {
-            if (typeof hostType !== "number" || hostType < EntityHostType.DOMAIN || hostType > EntityHostType.LOCAL) {
+            if (typeof hostType !== "number" || hostType < HostType.DOMAIN || hostType > HostType.LOCAL) {
                 console.error("[EntityServer] addEntity() called with invalid entity hostType!");
                 return new Uuid(Uuid.NULL);
             }
-            if (hostType === EntityHostType.AVATAR) {
+            if (hostType === HostType.AVATAR) {
                 console.error("[EntityServer] addEntity() for avatar entities not implemented!");
                 return new Uuid(Uuid.NULL);
             }
-            if (hostType === EntityHostType.LOCAL) {
+            if (hostType === HostType.LOCAL) {
                 console.error("[EntityServer] addEntity() for local entities not implemented!");
                 return new Uuid(Uuid.NULL);
             }
@@ -280,7 +280,7 @@ class EntityServer extends AssignmentClient {
             return new Uuid(Uuid.NULL);
         }
 
-        return this.#addEntityInternal(properties, hostType ?? EntityHostType.DOMAIN);
+        return this.#addEntityInternal(properties, hostType ?? HostType.DOMAIN);
     }
 
 
@@ -313,18 +313,18 @@ class EntityServer extends AssignmentClient {
         }
     }
 
-    #addEntityInternal(properties: EntityProperties, entityHostType: EntityHostType): Uuid {
+    #addEntityInternal(properties: EntityProperties, entityHostType: HostType): Uuid {
         // C++  QUuid EntityScriptingInterface::addEntityInternal(const EntityItemProperties& properties,
         //          entity::HostType entityHostType)
 
         // WEBRTC TODO: Address further C++ code - activity tracking.
 
         // WEBRTC TODO: Address further C++ code - avatar entities and local entities.
-        if (entityHostType === EntityHostType.AVATAR) {
+        if (entityHostType === HostType.AVATAR) {
             console.error("[EntityServer] addEntity() for avatar entities not implemented!");
             return new Uuid(Uuid.NULL);
         }
-        if (entityHostType === EntityHostType.LOCAL) {
+        if (entityHostType === HostType.LOCAL) {
             console.error("[EntityServer] addEntity() for local entities not implemented!");
             return new Uuid(Uuid.NULL);
         }
@@ -332,9 +332,9 @@ class EntityServer extends AssignmentClient {
         // WEBRTC TODO: Address further C++ code - avatar entities.
 
         const propertiesWithSimID = JSON.parse(JSON.stringify(properties)) as EntityProperties;
+        propertiesWithSimID.entityHostType = entityHostType;
 
         // WEBRTC TODO: Address further C++ code - avatar entities and local entities.
-        // propertiesWithSimID.entityHostType = entityHostType;
 
         propertiesWithSimID.created = BigInt(Date.now());
 

--- a/src/MessageMixer.ts
+++ b/src/MessageMixer.ts
@@ -138,7 +138,6 @@ class MessageMixer extends AssignmentClient {
             return;
         }
 
-
         this.#_messagesClient.sendMessage(channel, message, localOnly);
     }
 

--- a/src/Vircadia.ts
+++ b/src/Vircadia.ts
@@ -52,8 +52,14 @@ export { default as EntityServer } from "./EntityServer";
 export { default as MessageMixer } from "./MessageMixer";
 export type { AssignmentClientState } from "./domain/AssignmentClient";
 
+export { EntityHostType } from "./domain/entities/EntityHostType";
+export { EntityType } from "./domain/entities/EntityTypes";
+
 export { default as ModerationFlags } from "./domain/shared/ModerationFlags";
 export type { BanFlagsValue } from "./domain/shared/ModerationFlags";
+
+export { default as Quat } from "./domain/shared/Quat";
+export type { quat } from "./domain/shared/Quat";
 
 export { default as SignalEmitter } from "./domain/shared/SignalEmitter";
 export type { Signal, Slot } from "./domain/shared/SignalEmitter";
@@ -62,6 +68,3 @@ export { default as Uuid } from "./domain/shared/Uuid";
 
 export { default as Vec3 } from "./domain/shared/Vec3";
 export type { vec3 } from "./domain/shared/Vec3";
-
-export { default as Quat } from "./domain/shared/Quat";
-export type { quat } from "./domain/shared/Quat";

--- a/src/Vircadia.ts
+++ b/src/Vircadia.ts
@@ -52,7 +52,7 @@ export { default as EntityServer } from "./EntityServer";
 export { default as MessageMixer } from "./MessageMixer";
 export type { AssignmentClientState } from "./domain/AssignmentClient";
 
-export { EntityHostType } from "./domain/entities/EntityHostType";
+export { HostType } from "./domain/entities/EntityItem";
 export { EntityType } from "./domain/entities/EntityTypes";
 
 export { default as ModerationFlags } from "./domain/shared/ModerationFlags";

--- a/src/domain/entities/AmbientLightPropertyGroup.ts
+++ b/src/domain/entities/AmbientLightPropertyGroup.ts
@@ -11,7 +11,7 @@
 
 import UDT from "../networking/udt/UDT";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type AmbientLightProperties = {
@@ -73,13 +73,13 @@ class AmbientLightPropertyGroup {
         const textDecoder = new TextDecoder();
 
         let intensity: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_AMBIENT_LIGHT_INTENSITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_AMBIENT_LIGHT_INTENSITY)) {
             intensity = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let url: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_AMBIENT_LIGHT_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_AMBIENT_LIGHT_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {

--- a/src/domain/entities/AmbientLightPropertyGroup.ts
+++ b/src/domain/entities/AmbientLightPropertyGroup.ts
@@ -10,8 +10,7 @@
 //
 
 import UDT from "../networking/udt/UDT";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type AmbientLightProperties = {
@@ -61,7 +60,7 @@ class AmbientLightPropertyGroup {
      *      read.
      */
     static readEntitySubclassDataFromBuffer(data: DataView, position: number,
-        propertyFlags: PropertyFlags): AmbientLightPropertyGroupSubclassData {
+        propertyFlags: EntityPropertyFlags): AmbientLightPropertyGroupSubclassData {
         // C++  int AmbientLightPropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/BloomPropertyGroup.ts
+++ b/src/domain/entities/BloomPropertyGroup.ts
@@ -10,8 +10,7 @@
 //
 
 import UDT from "../networking/udt/UDT";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type BloomProperties = {
@@ -59,7 +58,7 @@ class BloomPropertyGroup {
      *  @returns {BloomPropertyGroupSubclassData} The Zone entity's bloom properties and the number of bytes read.
      */
     static readEntitySubclassDataFromBuffer(data: DataView, position: number,
-        propertyFlags: PropertyFlags): BloomPropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
+        propertyFlags: EntityPropertyFlags): BloomPropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int BloomPropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/BloomPropertyGroup.ts
+++ b/src/domain/entities/BloomPropertyGroup.ts
@@ -11,7 +11,7 @@
 
 import UDT from "../networking/udt/UDT";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type BloomProperties = {
@@ -69,19 +69,19 @@ class BloomPropertyGroup {
         let dataPosition = position;
 
         let intensity: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BLOOM_INTENSITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BLOOM_INTENSITY)) {
             intensity = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let threshold: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BLOOM_THRESHOLD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BLOOM_THRESHOLD)) {
             threshold = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let size: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BLOOM_SIZE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BLOOM_SIZE)) {
             size = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }

--- a/src/domain/entities/EntityEditPacketSender.ts
+++ b/src/domain/entities/EntityEditPacketSender.ts
@@ -1,0 +1,139 @@
+//
+//  EntityEditPacketSender.js
+//
+//  Created by David Rowe on 19 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { HostType } from "../entities/EntityItem";
+import EntityPropertyFlags, { EntityPropertyList } from "../entities/EntityPropertyFlags";
+import { EntityProperties } from "../networking/packets/EntityData";
+import PacketScribe from "../networking/packets/PacketScribe";
+import { PacketTypeValue } from "../networking/udt/PacketHeaders";
+import NLPacket from "../networking/NLPacket";
+import NodeList from "../networking/NodeList";
+import OctreeEditPacketSender from "../octree/OctreeEditPacketSender";
+import ContextManager from "../shared/ContextManager";
+import { bigintReplacer, bigintReviver } from "../shared/JSONExtensions";
+import Uuid from "../shared/Uuid";
+import EntityItemProperties from "./EntityItemProperties";
+
+
+/*@devdoc
+ *  The <code>EntityEditPacketSender</code> class handles preparing and sending entity edit packets to the entity server.
+ *  <p>C++: <code>class EntityEditPacketSender : public OctreeEditPacketSender</code></p>
+ *
+ *  @class EntityEditPacketSender
+ *  @param {number} contextID - The {@link ContextManager} context ID.
+ */
+class EntityEditPacketSender extends OctreeEditPacketSender {
+    // C++  class EntityEditPacketSender : public OctreeEditPacketSender
+
+    static override readonly contextItemType = "EntityEditPacketSender";
+
+
+    // Context
+    #_nodeList;
+
+
+    constructor(contextID: number) {
+        super(contextID);
+
+        // Context
+        this.#_nodeList = ContextManager.get(contextID, NodeList) as NodeList;
+    }
+
+
+    /*@devdoc
+     *  Sends an entity edit to the entity server as an {@link NLPacket} or {@link NLPacketList}.
+     *  <p>Note: The edit is sent reliably whereas the C++ sends it unreliably. The C++ can send it unreliably because it
+     *  maintains its own copy of the entity tree</p>
+     *  @param {PacketTypeValue} type - The entity edit packet type.
+     *  @param {Uuid} entityItemID - The entity ID.
+     *  @param {EntityProperties} properties - The properties to include in the entity edit.
+     */
+    queueEditEntityMessage(type: PacketTypeValue, entityItemID: Uuid, properties: EntityProperties): void {
+        // C++  void EntityEditPacketSender::queueEditEntityMessage(PacketType type, EntityTreePointer entityTree,
+        //          EntityItemID entityItemID, const EntityItemProperties& properties)
+
+        if (properties.entityHostType === HostType.AVATAR) {
+
+            // WEBRTC TODO: Address further C++ code - avatar entities.
+
+            console.error("[EntityEditPacketSender] queueEditEntityMessage() for avatar entities not implemented!");
+            return;
+        }
+        if (properties.entityHostType === HostType.LOCAL) {
+            // Don't send edits for local entities
+            return;
+        }
+
+        // WEBRTC TODO: Address further C++ code - serverless domains.
+
+        let didntFitProperties = new EntityPropertyFlags();
+        const propertiesCopy = JSON.parse(JSON.stringify(properties, bigintReplacer), bigintReviver) as EntityProperties;
+
+        if (properties.parentID && properties.parentID.value() === Uuid.AVATAR_SELF_ID) {
+            const myNodeID = this.#_nodeList.getSessionUUID();
+            propertiesCopy.parentID = myNodeID;
+        }
+
+        let requestedProperties = EntityItemProperties.getChangedProperties(propertiesCopy);
+
+        if (!this.#_nodeList.getThisNodeCanGetAndSetPrivateUserData()
+                && requestedProperties.getHasProperty(EntityPropertyList.PROP_PRIVATE_USER_DATA)) {
+            requestedProperties.setHasProperty(EntityPropertyList.PROP_PRIVATE_USER_DATA, false);
+        }
+
+        let packetType = type;
+        /*
+        let nlPacketList: NLPacketList | null = null;
+        */
+        let nlPacket: NLPacket | null = null;
+
+        let packetOverflow = false;
+        while (!requestedProperties.isEmpty() && !packetOverflow) {
+            // Create NLPacketList / NLPacket here rather than in queueOctreeEditMessage().
+            const entityOperationDetails = {
+                entityID: entityItemID,
+                properties: propertiesCopy,
+                requestedProperties,
+                didntFitProperties
+            };
+            if (packetType === PacketTypeValue.EntityAdd) {
+                // WEBRTC TODO: Implement EntityAdd.
+                /*
+                nlPacketList = PacketScribe.EntityAdd.write(entityOperationDetails);  // Creates a reliable packet.
+                this.queueOctreeEditMessage(type, nlPacketList);
+                */
+            } else {
+                switch (packetType) {
+                    case PacketTypeValue.EntityEdit:
+                        nlPacket = PacketScribe.EntityEdit.write(entityOperationDetails);  // Creates a reliable packet.
+                        break;
+                    default:
+                        // WEBRTC TODO: Address further packet types.
+                        console.error("[EntityEditPacketSender] Not implemented for packet type!", packetType);
+                        return;
+                }
+                if (nlPacket) {
+                    this.queueOctreeEditMessage(/* type, */ nlPacket);
+                } else {
+                    console.warn("[networking] Some properties didn't fit writing an EntityEdit packet - packet not sent.",
+                        entityOperationDetails.entityID.stringify());
+                    packetOverflow = true;
+                }
+            }
+
+            packetType = PacketTypeValue.EntityEdit;
+            requestedProperties = didntFitProperties;
+            didntFitProperties = new EntityPropertyFlags();
+        }
+    }
+}
+
+export default EntityEditPacketSender;

--- a/src/domain/entities/EntityHostType.ts
+++ b/src/domain/entities/EntityHostType.ts
@@ -1,0 +1,32 @@
+//
+//  EntityHostType.ts
+//
+//  Created by David Rowe on 19 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/*@sdkdoc
+ *  The <code>EntityHostType</code> namespace enumerates how an entity is hosted and sent to others for display.
+ *  @namespace EntityHostType
+ *  @property {number} DOMAIN - <code>0</code> - Domain entities are stored on the domain, are visible to everyone, and are sent
+ *      to everyone by the entity server.
+ *  @property {number} LOCAL - <code>1</code> - Avatar entities are stored on an Interface client, are visible to everyone, and
+ *      are sent to everyone by the avatar mixer. They follow the client to each domain visited, displaying at the same domain
+ *      coordinates unless parented to the client's avatar.
+ *  @property {number} AVATAR - <code>2</code> - Local entities are ephemeral — they aren't stored anywhere — and are visible
+ *      only to the client. They follow the client to each domain visited, displaying at the same domain coordinates unless
+ *      parented to the client's avatar. Additionally, local entities are always collisionless.
+ */
+enum EntityHostType {
+    // C++  namespace entity { enum class HostType }
+
+    DOMAIN = 0,
+    LOCAL,
+    AVATAR
+}
+
+export { EntityHostType };

--- a/src/domain/entities/EntityHostType.ts
+++ b/src/domain/entities/EntityHostType.ts
@@ -14,19 +14,19 @@
  *  @namespace EntityHostType
  *  @property {number} DOMAIN - <code>0</code> - Domain entities are stored on the domain, are visible to everyone, and are sent
  *      to everyone by the entity server.
- *  @property {number} LOCAL - <code>1</code> - Avatar entities are stored on an Interface client, are visible to everyone, and
- *      are sent to everyone by the avatar mixer. They follow the client to each domain visited, displaying at the same domain
- *      coordinates unless parented to the client's avatar.
- *  @property {number} AVATAR - <code>2</code> - Local entities are ephemeral — they aren't stored anywhere — and are visible
+ *  @property {number} AVATAR - <code>1</code> - Local entities are ephemeral — they aren't stored anywhere — and are visible
  *      only to the client. They follow the client to each domain visited, displaying at the same domain coordinates unless
  *      parented to the client's avatar. Additionally, local entities are always collisionless.
+ *  @property {number} LOCAL - <code>2</code> - Avatar entities are stored on an Interface client, are visible to everyone, and
+ *      are sent to everyone by the avatar mixer. They follow the client to each domain visited, displaying at the same domain
+ *      coordinates unless parented to the client's avatar.
  */
 enum EntityHostType {
     // C++  namespace entity { enum class HostType }
 
     DOMAIN = 0,
-    LOCAL,
-    AVATAR
+    AVATAR,
+    LOCAL
 }
 
 export { EntityHostType };

--- a/src/domain/entities/EntityItem.ts
+++ b/src/domain/entities/EntityItem.ts
@@ -1,5 +1,5 @@
 //
-//  EntityHostType.ts
+//  EntityItem.ts
 //
 //  Created by David Rowe on 19 Jun 2023.
 //  Copyright 2023 Vircadia contributors.
@@ -10,8 +10,9 @@
 //
 
 /*@sdkdoc
- *  The <code>EntityHostType</code> namespace enumerates how an entity is hosted and sent to others for display.
- *  @namespace EntityHostType
+ *  The <code>HostType</code> namespace enumerates how an entity is hosted and sent to others for display.
+ *  <p>C++: <code>HostType</code></p>
+ *  @namespace HostType
  *  @property {number} DOMAIN - <code>0</code> - Domain entities are stored on the domain, are visible to everyone, and are sent
  *      to everyone by the entity server.
  *  @property {number} AVATAR - <code>1</code> - Local entities are ephemeral — they aren't stored anywhere — and are visible
@@ -21,12 +22,12 @@
  *      are sent to everyone by the avatar mixer. They follow the client to each domain visited, displaying at the same domain
  *      coordinates unless parented to the client's avatar.
  */
-enum EntityHostType {
-    // C++  namespace entity { enum class HostType }
+enum HostType {
+    // C++  enum class HostType
 
     DOMAIN = 0,
     AVATAR,
     LOCAL
 }
 
-export { EntityHostType };
+export { HostType };

--- a/src/domain/entities/EntityItemProperties.ts
+++ b/src/domain/entities/EntityItemProperties.ts
@@ -364,11 +364,20 @@ class EntityItemProperties {
         };
 
 
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+        // WEBRTC TODO: Address further C++ code - other entity properties.
+
+        if (requestedProperties.getHasProperty(EntityPropertyList.PROP_PARENT_ID)) {
+            dataPosition += OctreePacketData.appendUUIDValue(data, dataPosition, EntityPropertyList.PROP_PARENT_ID,
+                properties.parentID ?? new Uuid(), packetContext);
+        }
+
         // WEBRTC TODO: Address further C++ code - other entity properties.
 
         if (requestedProperties.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)) {
-            assert(properties.lastEditedBy !== undefined);
-            dataPosition += OctreePacketData.appendUUIDValue(data, dataPosition, properties.lastEditedBy, packetContext);
+            dataPosition += OctreePacketData.appendUUIDValue(data, dataPosition, EntityPropertyList.PROP_LAST_EDITED_BY,
+                properties.lastEditedBy!, packetContext);
         }
 
         // WEBRTC TODO: Address further C++ code - other entity properties.
@@ -377,8 +386,8 @@ class EntityItemProperties {
             const entityProperties = properties as ShapeEntityProperties;
 
             if (requestedProperties.getHasProperty(EntityPropertyList.PROP_COLOR)) {
-                assert(entityProperties.color !== undefined);
-                dataPosition += OctreePacketData.appendColorValue(data, dataPosition, entityProperties.color, packetContext);
+                dataPosition += OctreePacketData.appendColorValue(data, dataPosition, EntityPropertyList.PROP_COLOR,
+                    entityProperties.color!, packetContext);
             }
 
             // WEBRTC TODO: Address further C++ code - other entity properties.
@@ -386,6 +395,8 @@ class EntityItemProperties {
         }
 
         // WEBRTC TODO: Address further C++ code - other entity properties.
+
+        /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
 
         propertyCount = packetContext.propertyCount;

--- a/src/domain/entities/EntityItemProperties.ts
+++ b/src/domain/entities/EntityItemProperties.ts
@@ -1,0 +1,289 @@
+//
+//  EntityItemProperties.ts
+//
+//  Created by David Rowe on 26 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { EntityProperties } from "../networking/packets/EntityData";
+import { EntityPropertyFlags, EntityPropertyList } from "./EntityPropertyFlags";
+
+
+/*@devdoc
+ *  The <code>EntityItemProperties</code> class provides methods for working with entity item properties.
+ *  <p>C++: <code>EntityItemProperties</code></p>
+ */
+class EntityItemProperties {
+    // C++: class EntityItemProperties
+
+    static readonly #_PROPERTY_MAP = new Map<string, number>([  // Maps property names to EntityPropertyList values.
+
+        // Core
+        ["simulationOwner", EntityPropertyList.PROP_SIMULATION_OWNER],
+        ["parentID", EntityPropertyList.PROP_PARENT_ID],
+        ["parentJointIndex", EntityPropertyList.PROP_PARENT_JOINT_INDEX],
+        ["visible", EntityPropertyList.PROP_VISIBLE],
+        ["name", EntityPropertyList.PROP_NAME],
+        ["locked", EntityPropertyList.PROP_LOCKED],
+        ["userData", EntityPropertyList.PROP_USER_DATA],
+        ["privateUserData", EntityPropertyList.PROP_PRIVATE_USER_DATA],
+        ["href", EntityPropertyList.PROP_HREF],
+        ["description", EntityPropertyList.PROP_DESCRIPTION],
+        ["position", EntityPropertyList.PROP_POSITION],
+        ["dimensions", EntityPropertyList.PROP_DIMENSIONS],
+        ["rotation", EntityPropertyList.PROP_ROTATION],
+        ["registrationPoint", EntityPropertyList.PROP_REGISTRATION_POINT],
+        ["created", EntityPropertyList.PROP_CREATED],
+        ["lastEditedBy", EntityPropertyList.PROP_LAST_EDITED_BY],
+        ["entityHostType", EntityPropertyList.PROP_ENTITY_HOST_TYPE],
+        ["owningAvatarID", EntityPropertyList.PROP_OWNING_AVATAR_ID],
+        ["queryAACube", EntityPropertyList.PROP_QUERY_AA_CUBE],
+        ["canCastShadow", EntityPropertyList.PROP_CAN_CAST_SHADOW],
+        ["isVisibleInSecondaryCamera", EntityPropertyList.PROP_VISIBLE_IN_SECONDARY_CAMERA],
+        ["renderLayer", EntityPropertyList.PROP_RENDER_LAYER],
+        ["primitiveMode", EntityPropertyList.PROP_PRIMITIVE_MODE],
+        ["ignorePickIntersection", EntityPropertyList.PROP_IGNORE_PICK_INTERSECTION],
+        ["renderWithZones", EntityPropertyList.PROP_RENDER_WITH_ZONES],
+        ["billboardMode", EntityPropertyList.PROP_BILLBOARD_MODE],
+        //changedProperties += _grab.getChangedProperties();
+
+        // Physics
+        ["density", EntityPropertyList.PROP_DENSITY],
+        ["velocity", EntityPropertyList.PROP_VELOCITY],
+        ["angularVelocity", EntityPropertyList.PROP_ANGULAR_VELOCITY],
+        ["gravity", EntityPropertyList.PROP_GRAVITY],
+        ["acceleration", EntityPropertyList.PROP_ACCELERATION],
+        ["damping", EntityPropertyList.PROP_DAMPING],
+        ["angularDamping", EntityPropertyList.PROP_ANGULAR_DAMPING],
+        ["restitution", EntityPropertyList.PROP_RESTITUTION],
+        ["friction", EntityPropertyList.PROP_FRICTION],
+        ["lifetime", EntityPropertyList.PROP_LIFETIME],
+        ["collisionless", EntityPropertyList.PROP_COLLISIONLESS],
+        ["collisionMask", EntityPropertyList.PROP_COLLISION_MASK],
+        ["dynamic", EntityPropertyList.PROP_DYNAMIC],
+        ["collisionSoundURL", EntityPropertyList.PROP_COLLISION_SOUND_URL],
+        ["actionData", EntityPropertyList.PROP_ACTION_DATA],
+
+        // Cloning
+        ["cloneable", EntityPropertyList.PROP_CLONEABLE],
+        ["cloneLifetime", EntityPropertyList.PROP_CLONE_LIFETIME],
+        ["cloneLimit", EntityPropertyList.PROP_CLONE_LIMIT],
+        ["cloneDynamic", EntityPropertyList.PROP_CLONE_DYNAMIC],
+        ["cloneAvatarEntity", EntityPropertyList.PROP_CLONE_AVATAR_ENTITY],
+        ["cloneOriginID", EntityPropertyList.PROP_CLONE_ORIGIN_ID],
+
+        // Scripts
+        ["script", EntityPropertyList.PROP_SCRIPT],
+        ["scriptTimestamp", EntityPropertyList.PROP_SCRIPT_TIMESTAMP],
+        ["serverScripts", EntityPropertyList.PROP_SERVER_SCRIPTS],
+
+        // Certifiable Properties
+        ["itemName", EntityPropertyList.PROP_ITEM_NAME],
+        ["itemDescription", EntityPropertyList.PROP_ITEM_DESCRIPTION],
+        ["itemCategories", EntityPropertyList.PROP_ITEM_CATEGORIES],
+        ["itemArtist", EntityPropertyList.PROP_ITEM_ARTIST],
+        ["itemLicense", EntityPropertyList.PROP_ITEM_LICENSE],
+        ["limitedRun", EntityPropertyList.PROP_LIMITED_RUN],
+        ["marketplaceID", EntityPropertyList.PROP_MARKETPLACE_ID],
+        ["editionNumber", EntityPropertyList.PROP_EDITION_NUMBER],
+        ["entityInstanceNumber", EntityPropertyList.PROP_ENTITY_INSTANCE_NUMBER],
+        ["certificateID", EntityPropertyList.PROP_CERTIFICATE_ID],
+        ["certificateType", EntityPropertyList.PROP_CERTIFICATE_TYPE],
+        ["staticCertificateVersion", EntityPropertyList.PROP_STATIC_CERTIFICATE_VERSION],
+
+        // Location data for scripts
+        ["localPosition", EntityPropertyList.PROP_LOCAL_POSITION],
+        ["localRotation", EntityPropertyList.PROP_LOCAL_ROTATION],
+        ["localVelocity", EntityPropertyList.PROP_LOCAL_VELOCITY],
+        ["localAngularVelocity", EntityPropertyList.PROP_LOCAL_ANGULAR_VELOCITY],
+        ["localDimensions", EntityPropertyList.PROP_LOCAL_DIMENSIONS],
+
+        // Common
+        ["shapeType", EntityPropertyList.PROP_SHAPE_TYPE],
+        ["compoundShapeURL", EntityPropertyList.PROP_COMPOUND_SHAPE_URL],
+        ["color", EntityPropertyList.PROP_COLOR],
+        ["alpha", EntityPropertyList.PROP_ALPHA],
+        //changedProperties += _pulse.getChangedProperties();
+        // ...PulsePropertyGroup.PROPERTY_MAP,  // Pulse properties are deprecated and aren't implemented in the Web SDK.
+        ["textures", EntityPropertyList.PROP_TEXTURES],
+
+        // Particles
+        ["maxParticles", EntityPropertyList.PROP_MAX_PARTICLES],
+        ["lifespan", EntityPropertyList.PROP_LIFESPAN],
+        ["isEmitting", EntityPropertyList.PROP_EMITTING_PARTICLES],
+        ["emitRate", EntityPropertyList.PROP_EMIT_RATE],
+        ["emitSpeed", EntityPropertyList.PROP_EMIT_SPEED],
+        ["speedSpread", EntityPropertyList.PROP_SPEED_SPREAD],
+        ["emitOrientation", EntityPropertyList.PROP_EMIT_ORIENTATION],
+        ["emitDimensions", EntityPropertyList.PROP_EMIT_DIMENSIONS],
+        ["emitRadiusStart", EntityPropertyList.PROP_EMIT_RADIUS_START],
+        ["polarStart", EntityPropertyList.PROP_POLAR_START],
+        ["polarFinish", EntityPropertyList.PROP_POLAR_FINISH],
+        ["azimuthStart", EntityPropertyList.PROP_AZIMUTH_START],
+        ["azimuthFinish", EntityPropertyList.PROP_AZIMUTH_FINISH],
+        ["emitAcceleration", EntityPropertyList.PROP_EMIT_ACCELERATION],
+        ["accelerationSpread", EntityPropertyList.PROP_ACCELERATION_SPREAD],
+        ["particleRadius", EntityPropertyList.PROP_PARTICLE_RADIUS],
+        ["radiusSpread", EntityPropertyList.PROP_RADIUS_SPREAD],
+        ["radiusStart", EntityPropertyList.PROP_RADIUS_START],
+        ["radiusFinish", EntityPropertyList.PROP_RADIUS_FINISH],
+        ["colorSpread", EntityPropertyList.PROP_COLOR_SPREAD],
+        ["colorStart", EntityPropertyList.PROP_COLOR_START],
+        ["colorFinish", EntityPropertyList.PROP_COLOR_FINISH],
+        ["alphaSpread", EntityPropertyList.PROP_ALPHA_SPREAD],
+        ["alphaStart", EntityPropertyList.PROP_ALPHA_START],
+        ["alphaFinish", EntityPropertyList.PROP_ALPHA_FINISH],
+        ["emitterShouldTrail", EntityPropertyList.PROP_EMITTER_SHOULD_TRAIL],
+        ["particleSpin", EntityPropertyList.PROP_PARTICLE_SPIN],
+        ["spinSpread", EntityPropertyList.PROP_SPIN_SPREAD],
+        ["spinStart", EntityPropertyList.PROP_SPIN_START],
+        ["spinFinish", EntityPropertyList.PROP_SPIN_FINISH],
+        ["rotateWithEntity", EntityPropertyList.PROP_PARTICLE_ROTATE_WITH_ENTITY],
+
+        // Model
+        ["modelURL", EntityPropertyList.PROP_MODEL_URL],
+        ["modelScale", EntityPropertyList.PROP_MODEL_SCALE],
+        ["jointRotationsSet", EntityPropertyList.PROP_JOINT_ROTATIONS_SET],
+        ["jointRotations", EntityPropertyList.PROP_JOINT_ROTATIONS],
+        ["jointTranslationsSet", EntityPropertyList.PROP_JOINT_TRANSLATIONS_SET],
+        ["jointTranslations", EntityPropertyList.PROP_JOINT_TRANSLATIONS],
+        ["relayParentJoints", EntityPropertyList.PROP_RELAY_PARENT_JOINTS],
+        ["groupCulled", EntityPropertyList.PROP_GROUP_CULLED],
+        ["blendshapeCoefficiengts", EntityPropertyList.PROP_BLENDSHAPE_COEFFICIENTS],
+        ["useOriginalPivot", EntityPropertyList.PROP_USE_ORIGINAL_PIVOT],
+        //changedProperties += _animation.getChangedProperties();
+
+        // Light
+        ["isSpotlight", EntityPropertyList.PROP_IS_SPOTLIGHT],
+        ["intensity", EntityPropertyList.PROP_INTENSITY],
+        ["exponent", EntityPropertyList.PROP_EXPONENT],
+        ["cutoff", EntityPropertyList.PROP_CUTOFF],
+        ["falloffRadius", EntityPropertyList.PROP_FALLOFF_RADIUS],
+
+        // Text
+        ["text", EntityPropertyList.PROP_TEXT],
+        ["lineHeight", EntityPropertyList.PROP_LINE_HEIGHT],
+        ["textColor", EntityPropertyList.PROP_TEXT_COLOR],
+        ["textAlpha", EntityPropertyList.PROP_TEXT_ALPHA],
+        ["backgroundColor", EntityPropertyList.PROP_BACKGROUND_COLOR],
+        ["backgroundAlpha", EntityPropertyList.PROP_BACKGROUND_ALPHA],
+        ["leftMargin", EntityPropertyList.PROP_LEFT_MARGIN],
+        ["rightMargin", EntityPropertyList.PROP_RIGHT_MARGIN],
+        ["topMargin", EntityPropertyList.PROP_TOP_MARGIN],
+        ["bottomMargin", EntityPropertyList.PROP_BOTTOM_MARGIN],
+        ["unlit", EntityPropertyList.PROP_UNLIT],
+        ["font", EntityPropertyList.PROP_FONT],
+        ["textEffect", EntityPropertyList.PROP_TEXT_EFFECT],
+        ["textEffectColor", EntityPropertyList.PROP_TEXT_EFFECT_COLOR],
+        ["textEffectThickness", EntityPropertyList.PROP_TEXT_EFFECT_THICKNESS],
+        ["alignment", EntityPropertyList.PROP_TEXT_ALIGNMENT],
+
+        // Zone
+        //changedProperties += _keyLight.getChangedProperties();
+        //changedProperties += _ambientLight.getChangedProperties();
+        //changedProperties += _skybox.getChangedProperties();
+        //changedProperties += _haze.getChangedProperties();
+        //changedProperties += _bloom.getChangedProperties();
+        ["flyingAllowed", EntityPropertyList.PROP_FLYING_ALLOWED],
+        ["ghostingAllowed", EntityPropertyList.PROP_GHOSTING_ALLOWED],
+        ["filterURL", EntityPropertyList.PROP_FILTER_URL],
+        ["keyLightMode", EntityPropertyList.PROP_KEY_LIGHT_MODE],
+        ["amgientLightMode", EntityPropertyList.PROP_AMBIENT_LIGHT_MODE],
+        ["skyboxMode", EntityPropertyList.PROP_SKYBOX_MODE],
+        ["hazeMode", EntityPropertyList.PROP_HAZE_MODE],
+        ["bloomMode", EntityPropertyList.PROP_BLOOM_MODE],
+        ["avatarPriority", EntityPropertyList.PROP_AVATAR_PRIORITY],
+        ["screenshare", EntityPropertyList.PROP_SCREENSHARE],
+
+        // Polyvox
+        ["voxelVolumeSize", EntityPropertyList.PROP_VOXEL_VOLUME_SIZE],
+        ["voxelData", EntityPropertyList.PROP_VOXEL_DATA],
+        ["voxelSurfaceStyle", EntityPropertyList.PROP_VOXEL_SURFACE_STYLE],
+        ["xTextureURL", EntityPropertyList.PROP_X_TEXTURE_URL],
+        ["yTextureURL", EntityPropertyList.PROP_Y_TEXTURE_URL],
+        ["zTextureURL", EntityPropertyList.PROP_Z_TEXTURE_URL],
+        ["xNNeighborID", EntityPropertyList.PROP_X_N_NEIGHBOR_ID],
+        ["yNNeighborID", EntityPropertyList.PROP_Y_N_NEIGHBOR_ID],
+        ["zNNeighborID", EntityPropertyList.PROP_Z_N_NEIGHBOR_ID],
+        ["xPNeighborID", EntityPropertyList.PROP_X_P_NEIGHBOR_ID],
+        ["yPNeighborID", EntityPropertyList.PROP_Y_P_NEIGHBOR_ID],
+        ["zPNeighborID", EntityPropertyList.PROP_Z_P_NEIGHBOR_ID],
+
+        // Web
+        ["sourceUrl", EntityPropertyList.PROP_SOURCE_URL],
+        ["dpi", EntityPropertyList.PROP_DPI],
+        ["scriptURL", EntityPropertyList.PROP_SCRIPT_URL],
+        ["maxFPS", EntityPropertyList.PROP_MAX_FPS],
+        ["inputMode", EntityPropertyList.PROP_INPUT_MODE],
+        ["showKeyboardFocusHighlight", EntityPropertyList.PROP_SHOW_KEYBOARD_FOCUS_HIGHLIGHT],
+        ["useBackground", EntityPropertyList.PROP_WEB_USE_BACKGROUND],
+        ["userAgent", EntityPropertyList.PROP_USER_AGENT],
+
+        // Polyline
+        ["linePoints", EntityPropertyList.PROP_LINE_POINTS],
+        ["strokeWidths", EntityPropertyList.PROP_STROKE_WIDTHS],
+        ["normals", EntityPropertyList.PROP_STROKE_NORMALS],
+        ["strokeColors", EntityPropertyList.PROP_STROKE_COLORS],
+        ["isUVModeStretch", EntityPropertyList.PROP_IS_UV_MODE_STRETCH],
+        ["glow", EntityPropertyList.PROP_LINE_GLOW],
+        ["faceCamera", EntityPropertyList.PROP_LINE_FACE_CAMERA],
+
+        // Shape
+        ["shape", EntityPropertyList.PROP_SHAPE],
+
+        // Material
+        ["materialURL", EntityPropertyList.PROP_MATERIAL_URL],
+        ["materialMappingMode", EntityPropertyList.PROP_MATERIAL_MAPPING_MODE],
+        ["priority", EntityPropertyList.PROP_MATERIAL_PRIORITY],
+        ["parentMaterialName", EntityPropertyList.PROP_PARENT_MATERIAL_NAME],
+        ["materialMappingPos", EntityPropertyList.PROP_MATERIAL_MAPPING_POS],
+        ["materialMappingScale", EntityPropertyList.PROP_MATERIAL_MAPPING_SCALE],
+        ["materialMappingRot", EntityPropertyList.PROP_MATERIAL_MAPPING_ROT],
+        ["materialData", EntityPropertyList.PROP_MATERIAL_DATA],
+        ["materialRepeat", EntityPropertyList.PROP_MATERIAL_REPEAT],
+
+        // Image
+        ["imageURL", EntityPropertyList.PROP_IMAGE_URL],
+        ["emissive", EntityPropertyList.PROP_EMISSIVE],
+        ["keepAspectRatio", EntityPropertyList.PROP_KEEP_ASPECT_RATIO],
+        ["subImage", EntityPropertyList.PROP_SUB_IMAGE],
+
+        // Grid
+        ["followCamera", EntityPropertyList.PROP_GRID_FOLLOW_CAMERA],
+        ["majorGridEvery", EntityPropertyList.PROP_MAJOR_GRID_EVERY],
+        ["minorGridEvery", EntityPropertyList.PROP_MINOR_GRID_EVERY],
+
+        // Gizmo
+        ["gizmoType", EntityPropertyList.PROP_GIZMO_TYPE],
+        //changedProperties += _ring.getChangedProperties();
+    ]);
+
+    /*@devdoc
+     *  Gets property flags for all properties set in the entity properties object passed in, assuming that they may be changes.
+     *  <p>Note: The SDK doesn't maintain its own entity tree so it doesn't calculate whether the property values have actually
+     *  changed.</p>
+     *  @param {EntityPropertyFlags} properties - A set of entity properties and values.
+     *  @returns {EntityPropertyFlags} Flags for all the properties included in the entity properties object.
+     */
+    static getChangedProperties(properties: EntityProperties): EntityPropertyFlags {
+        // C++  EntityPropertyFlags EntityItemProperties::getChangedProperties() const
+
+        const changedProperties = new EntityPropertyFlags();
+        const propertyNames = Object.keys(properties);
+        for (const propertyName of propertyNames) {
+            const propertyValue = EntityItemProperties.#_PROPERTY_MAP.get(propertyName);
+            if (propertyValue !== undefined) {
+                changedProperties.setHasProperty(propertyValue, true);
+            }
+            // WEBRTC TODO: Handle group properties.
+        }
+        return changedProperties;
+    }
+
+}
+
+export default EntityItemProperties;

--- a/src/domain/entities/EntityItemProperties.ts
+++ b/src/domain/entities/EntityItemProperties.ts
@@ -324,6 +324,7 @@ class EntityItemProperties {
 
         // Simplification: The server doesn't actually use octcode data (see EntityItemProperties::decodeEntityEditPacket()) and
         // we're not compressing data so we can write an empty octcode value.
+        // WEBRTC TODO: Support compressing data?
         data.setUint8(dataPosition, 0);
         dataPosition += 1;
 

--- a/src/domain/entities/EntityPropertyFlags.ts
+++ b/src/domain/entities/EntityPropertyFlags.ts
@@ -10,228 +10,211 @@
 //
 
 /*@devdoc
- *  The <code>EntityPropertyFlags</code> namespace provides the positions of the flags in {@link PropertyFlags}.
- *  <table>
- *      <thead>
- *          <tr><th>Name</th><th>Value</th><th>Description</th></tr>
- *      </thead>
- *      <tbody>
- *          <tr><td>PROP_PAGED_PROPERTY</td><td>0</td><td>Paged property flag.</td></tr>
- *          <tr><td>PROP_CUSTOM_PROPERTIES_INCLUDED</td><td>1</td><td>Custom properties included flag.</td></tr>
- *          <tr><td>PROP_SIMULATION_OWNER</td><td>2</td><td>Simulation owner flag.</td></tr>
- *          <tr><td>PROP_PARENT_ID</td><td>3</td><td>Parent id flag.</td></tr>
- *          <tr><td>PROP_PARENT_JOINT_INDEX</td><td>4</td><td>Parent joint index flag.</td></tr>
- *          <tr><td>PROP_VISIBLE</td><td>5</td><td>Visible flag.</td></tr>
- *          <tr><td>PROP_NAME</td><td>6</td><td>Name flag.</td></tr>
- *          <tr><td>PROP_LOCKED</td><td>7</td><td>Locked flag.</td></tr>
- *          <tr><td>PROP_USER_DATA</td><td>8</td><td>User data flag.</td></tr>
- *          <tr><td>PROP_PRIVATE_USER_DATA</td><td>9</td><td>Private user data flag.</td></tr>
- *          <tr><td>PROP_HREF</td><td>10</td><td>Href flag.</td></tr>
- *          <tr><td>PROP_DESCRIPTION</td><td>11</td><td>Description flag.</td></tr>
- *          <tr><td>PROP_POSITION</td><td>12</td><td>Position flag.</td></tr>
- *          <tr><td>PROP_DIMENSIONS</td><td>13</td><td>Dimensions flag.</td></tr>
- *          <tr><td>PROP_ROTATION</td><td>14</td><td>Rotation flag.</td></tr>
- *          <tr><td>PROP_REGISTRATION_POINT</td><td>15</td><td>Registration point flag.</td></tr>
- *          <tr><td>PROP_CREATED</td><td>16</td><td>Created flag.</td></tr>
- *          <tr><td>PROP_LAST_EDITED_BY</td><td>17</td><td>Last edited by flag.</td></tr>
- *          <tr><td>PROP_ENTITY_HOST_TYPE</td><td>18</td><td>Entity host type flag.</td></tr>
- *          <tr><td>PROP_OWNING_AVATAR_ID</td><td>19</td><td>Owning avatar id flag.</td></tr>
- *          <tr><td>PROP_QUERY_AA_CUBE</td><td>20</td><td>Query aa cube flag.</td></tr>
- *          <tr><td>PROP_CAN_CAST_SHADOW</td><td>21</td><td>Can cast shadow flag.</td></tr>
- *          <tr><td>PROP_VISIBLE_IN_SECONDARY_CAMERA</td><td>22</td><td>Visible in secondary camera flag.</td></tr>
- *          <tr><td>PROP_RENDER_LAYER</td><td>23</td><td>Render layer flag.</td></tr>
- *          <tr><td>PROP_PRIMITIVE_MODE</td><td>24</td><td>Primitive mode flag.</td></tr>
- *          <tr><td>PROP_IGNORE_PICK_INTERSECTION</td><td>25</td><td>Ignore pick intersection flag.</td></tr>
- *          <tr><td>PROP_RENDER_WITH_ZONES</td><td>26</td><td>Render with zones flag.</td></tr>
- *          <tr><td>PROP_BILLBOARD_MODE</td><td>27</td><td>Billboard mode flag.</td></tr>
- *          <tr><td>PROP_GRAB_GRABBABLE</td><td>28</td><td>Grab grabbable flag.</td></tr>
- *          <tr><td>PROP_GRAB_KINEMATIC</td><td>29</td><td>Grab kinematic flag.</td></tr>
- *          <tr><td>PROP_GRAB_FOLLOWS_CONTROLLER</td><td>30</td><td>Grab follows controller flag.</td></tr>
- *          <tr><td>PROP_GRAB_TRIGGERABLE</td><td>31</td><td>Grab triggerable flag.</td></tr>
- *          <tr><td>PROP_GRAB_EQUIPPABLE</td><td>32</td><td>Grab equippable flag.</td></tr>
- *          <tr><td>PROP_GRAB_DELEGATE_TO_PARENT</td><td>33</td><td>Grab delegate to parent flag.</td></tr>
- *          <tr><td>PROP_GRAB_LEFT_EQUIPPABLE_POSITION_OFFSET</td><td>34</td><td>Grab left equippable position offset flag.</td>
- *          </tr>
- *          <tr><td>PROP_GRAB_LEFT_EQUIPPABLE_ROTATION_OFFSET</td><td>35</td><td>Grab left equippable rotation offset flag.</td>
- *          </tr>
- *          <tr><td>PROP_GRAB_RIGHT_EQUIPPABLE_POSITION_OFFSET</td><td>36</td><td>Grab right equippable position offset flag.
- *          </td></tr>
- *          <tr><td>PROP_GRAB_RIGHT_EQUIPPABLE_ROTATION_OFFSET</td><td>37</td><td>Grab right equippable rotation offset flag.
- *          </td></tr>
- *          <tr><td>PROP_GRAB_EQUIPPABLE_INDICATOR_URL</td><td>38</td><td>Grab equippable indicator url flag.</td></tr>
- *          <tr><td>PROP_GRAB_EQUIPPABLE_INDICATOR_SCALE</td><td>39</td><td>Grab equippable indicator scale flag.</td></tr>
- *          <tr><td>PROP_GRAB_EQUIPPABLE_INDICATOR_OFFSET</td><td>40</td><td>Grab equippable indicator offset flag.</td></tr>
- *          <tr><td>PROP_DENSITY</td><td>41</td><td>Density flag.</td></tr>
- *          <tr><td>PROP_VELOCITY</td><td>42</td><td>Velocity flag.</td></tr>
- *          <tr><td>PROP_ANGULAR_VELOCITY</td><td>43</td><td>Angular velocity flag.</td></tr>
- *          <tr><td>PROP_GRAVITY</td><td>44</td><td>Gravity flag.</td></tr>
- *          <tr><td>PROP_ACCELERATION</td><td>45</td><td>Acceleration flag.</td></tr>
- *          <tr><td>PROP_DAMPING</td><td>46</td><td>Damping flag.</td></tr>
- *          <tr><td>PROP_ANGULAR_DAMPING</td><td>47</td><td>Angular damping flag.</td></tr>
- *          <tr><td>PROP_RESTITUTION</td><td>48</td><td>Restitution flag.</td></tr>
- *          <tr><td>PROP_FRICTION</td><td>49</td><td>Friction flag.</td></tr>
- *          <tr><td>PROP_LIFETIME</td><td>50</td><td>Lifetime flag.</td></tr>
- *          <tr><td>PROP_COLLISIONLESS</td><td>51</td><td>Collisionless flag.</td></tr>
- *          <tr><td>PROP_COLLISION_MASK</td><td>52</td><td>Collision mask flag.</td></tr>
- *          <tr><td>PROP_DYNAMIC</td><td>53</td><td>Dynamic flag.</td></tr>
- *          <tr><td>PROP_COLLISION_SOUND_URL</td><td>54</td><td>Collision sound url flag.</td></tr>
- *          <tr><td>PROP_ACTION_DATA</td><td>55</td><td>Action data flag.</td></tr>
- *          <tr><td>PROP_CLONEABLE</td><td>56</td><td>Cloneable flag.</td></tr>
- *          <tr><td>PROP_CLONE_LIFETIME</td><td>57</td><td>Clone lifetime flag.</td></tr>
- *          <tr><td>PROP_CLONE_LIMIT</td><td>58</td><td>Clone limit flag.</td></tr>
- *          <tr><td>PROP_CLONE_DYNAMIC</td><td>59</td><td>Clone dynamic flag.</td></tr>
- *          <tr><td>PROP_CLONE_AVATAR_ENTITY</td><td>60</td><td>Clone avatar entity flag.</td></tr>
- *          <tr><td>PROP_CLONE_ORIGIN_ID</td><td>61</td><td>Clone origin id flag.</td></tr>
- *          <tr><td>PROP_SCRIPT</td><td>62</td><td>Script flag.</td></tr>
- *          <tr><td>PROP_SCRIPT_TIMESTAMP</td><td>63</td><td>Script timestamp flag.</td></tr>
- *          <tr><td>PROP_SERVER_SCRIPTS</td><td>64</td><td>Server scripts flag.</td></tr>
- *          <tr><td>PROP_ITEM_NAME</td><td>65</td><td>Item name flag.</td></tr>
- *          <tr><td>PROP_ITEM_DESCRIPTION</td><td>66</td><td>Item description flag.</td></tr>
- *          <tr><td>PROP_ITEM_CATEGORIES</td><td>67</td><td>Item categories flag.</td></tr>
- *          <tr><td>PROP_ITEM_ARTIST</td><td>68</td><td>Item artist flag.</td></tr>
- *          <tr><td>PROP_ITEM_LICENSE</td><td>69</td><td>Item license flag.</td></tr>
- *          <tr><td>PROP_LIMITED_RUN</td><td>70</td><td>Limited run flag.</td></tr>
- *          <tr><td>PROP_MARKETPLACE_ID</td><td>71</td><td>Marketplace id flag.</td></tr>
- *          <tr><td>PROP_EDITION_NUMBER</td><td>72</td><td>Edition number flag.</td></tr>
- *          <tr><td>PROP_ENTITY_INSTANCE_NUMBER</td><td>73</td><td>Entity instance number flag.</td></tr>
- *          <tr><td>PROP_CERTIFICATE_ID</td><td>74</td><td>Certificate id flag.</td></tr>
- *          <tr><td>PROP_CERTIFICATE_TYPE</td><td>75</td><td>Certificate type flag.</td></tr>
- *          <tr><td>PROP_STATIC_CERTIFICATE_VERSION</td><td>76</td><td>Static certificate version flag.</td></tr>
- *          <tr><td>PROP_LOCAL_POSITION</td><td>77</td><td>Local position flag.</td></tr>
- *          <tr><td>PROP_LOCAL_ROTATION</td><td>78</td><td>Local rotation flag.</td></tr>
- *          <tr><td>PROP_LOCAL_VELOCITY</td><td>79</td><td>Local velocity flag.</td></tr>
- *          <tr><td>PROP_LOCAL_ANGULAR_VELOCITY</td><td>80</td><td>Local angular velocity flag.</td></tr>
- *          <tr><td>PROP_LOCAL_DIMENSIONS</td><td>81</td><td>Local dimensions flag.</td></tr>
- *          <tr><td>PROP_SHAPE_TYPE</td><td>82</td><td>Shape type flag.</td></tr>
- *          <tr><td>PROP_COMPOUND_SHAPE_URL</td><td>83</td><td>Compound shape url flag.</td></tr>
- *          <tr><td>PROP_COLOR</td><td>84</td><td>Color flag.</td></tr>
- *          <tr><td>PROP_ALPHA</td><td>85</td><td>Alpha flag.</td></tr>
- *          <tr><td>PROP_PULSE_MIN</td><td>86</td><td>Pulse min flag.</td></tr>
- *          <tr><td>PROP_PULSE_MAX</td><td>87</td><td>Pulse max flag.</td></tr>
- *          <tr><td>PROP_PULSE_PERIOD</td><td>88</td><td>Pulse period flag.</td></tr>
- *          <tr><td>PROP_PULSE_COLOR_MODE</td><td>89</td><td>Pulse color mode flag.</td></tr>
- *          <tr><td>PROP_PULSE_ALPHA_MODE</td><td>90</td><td>Pulse alpha mode flag.</td></tr>
- *          <tr><td>PROP_TEXTURES</td><td>91</td><td>Textures flag.</td></tr>
- *          <tr><td>PROP_DERIVED_0</td><td>92</td><td>Derived 0 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_1</td><td>93</td><td>Derived 1 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_2</td><td>94</td><td>Derived 2 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_3</td><td>95</td><td>Derived 3 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_4</td><td>96</td><td>Derived 4 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_5</td><td>97</td><td>Derived 5 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_6</td><td>98</td><td>Derived 6 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_7</td><td>99</td><td>Derived 7 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_8</td><td>100</td><td>Derived 8 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_9</td><td>101</td><td>Derived 9 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_10</td><td>102</td><td>Derived 10 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_11</td><td>103</td><td>Derived 11 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_12</td><td>104</td><td>Derived 12 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_13</td><td>105</td><td>Derived 13 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_14</td><td>106</td><td>Derived 14 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_15</td><td>107</td><td>Derived 15 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_16</td><td>108</td><td>Derived 16 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_17</td><td>109</td><td>Derived 17 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_18</td><td>110</td><td>Derived 18 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_19</td><td>111</td><td>Derived 19 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_20</td><td>112</td><td>Derived 20 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_21</td><td>113</td><td>Derived 21 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_22</td><td>114</td><td>Derived 22 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_23</td><td>115</td><td>Derived 23 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_24</td><td>116</td><td>Derived 24 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_25</td><td>117</td><td>Derived 25 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_26</td><td>118</td><td>Derived 26 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_27</td><td>119</td><td>Derived 27 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_28</td><td>120</td><td>Derived 28 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_29</td><td>121</td><td>Derived 29 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_30</td><td>122</td><td>Derived 30 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_31</td><td>123</td><td>Derived 31 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_32</td><td>124</td><td>Derived 32 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_33</td><td>125</td><td>Derived 33 flag.</td></tr>
- *          <tr><td>PROP_DERIVED_34</td><td>126</td><td>Derived 34 flag.</td></tr>
- *          <tr><td>PROP_AFTER_LAST_ITEM</td><td>127</td><td>After last item flag.</td></tr>
- *          <tr><td>PROP_MAX_PARTICLES</td><td>{@link EntityPropertyFlags|PROP_DERIVED_0}</td><td>Max particles flag. First
- *          ParticleEffect entity-specific property.</td></tr>
- *          <tr><td>PROP_LIFESPAN</td><td>{@link EntityPropertyFlags|PROP_DERIVED_1}</td><td>Lifespan flag.</td></tr>
- *          <tr><td>PROP_EMITTING_PARTICLES</td><td>{@link EntityPropertyFlags|PROP_DERIVED_2}</td><td>Emitting_particles flag.
- *          </td></tr>
- *          <tr><td>PROP_EMIT_RATE</td><td>{@link EntityPropertyFlags|PROP_DERIVED_3}</td><td>Emit rate flag.</td></tr>
- *          <tr><td>PROP_EMIT_SPEED</td><td>{@link EntityPropertyFlags|PROP_DERIVED_4}</td><td>Emit speed flag.</td></tr>
- *          <tr><td>PROP_SPEED_SPREAD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_5}</td><td>Speed spread flag.</td></tr>
- *          <tr><td>PROP_EMIT_ORIENTATION</td><td>{@link EntityPropertyFlags|PROP_DERIVED_6}</td><td>Emit orientation flag.
- *          </td></tr>
- *          <tr><td>PROP_EMIT_DIMENSIONS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_7}</td><td>Emit dimensions flag.</td>
- *          </tr>
- *          <tr><td>PROP_ACCELERATION_SPREAD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_8}</td><td>Acceleration spread
- *          flag.</td></tr>
- *          <tr><td>PROP_POLAR_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_9}</td><td>Polar start flag.</td></tr>
- *          <tr><td>PROP_POLAR_FINISH</td><td>{@link EntityPropertyFlags|PROP_DERIVED_10}</td><td>Polar finish flag.</td></tr>
- *          <tr><td>PROP_AZIMUTH_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_11}</td><td>Azimuth start flag.</td></tr>
- *          <tr><td>PROP_AZIMUTH_FINISH</td><td>{@link EntityPropertyFlags|PROP_DERIVED_12}</td><td>Azimuth finish flag.</td>
- *          </tr>
- *          <tr><td>PROP_EMIT_RADIUS_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_13}</td><td>Emit radius start flag.
- *          </td></tr>
- *          <tr><td>PROP_EMIT_ACCELERATION</td><td>{@link EntityPropertyFlags|PROP_DERIVED_14}</td><td>Emit acceleration flag.
- *          </td></tr>
- *          <tr><td>PROP_PARTICLE_RADIUS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_15}</td><td>Particle radius flag.</td>
- *          </tr>
- *          <tr><td>PROP_RADIUS_SPREAD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_16}</td><td>Radius spread flag.</td></tr>
- *          <tr><td>PROP_RADIUS_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_17}</td><td>Radius start flag.</td></tr>
- *          <tr><td>PROP_RADIUS_FINISH</td><td>{@link EntityPropertyFlags|PROP_DERIVED_18}</td><td>Radius finish flag.</td></tr>
- *          <tr><td>PROP_COLOR_SPREAD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_19}</td><td>Color spread flag.</td></tr>
- *          <tr><td>PROP_COLOR_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_20}</td><td>Color start flag.</td></tr>
- *          <tr><td>PROP_COLOR_FINISH</td><td>{@link EntityPropertyFlags|PROP_DERIVED_21}</td><td>Color finish flag.</td></tr>
- *          <tr><td>PROP_ALPHA_SPREAD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_22}</td><td>Alpha spread flag.</td></tr>
- *          <tr><td>PROP_ALPHA_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_23}</td><td>Alpha start flag.</td></tr>
- *          <tr><td>PROP_ALPHA_FINISH</td><td>{@link EntityPropertyFlags|PROP_DERIVED_24}</td><td>Alpha finish flag.</td></tr>
- *          <tr><td>PROP_EMITTER_SHOULD_TRAIL</td><td>{@link EntityPropertyFlags|PROP_DERIVED_25}</td><td>Emitter should trail
- *          flag.</td></tr>
- *          <tr><td>PROP_PARTICLE_SPIN</td><td>{@link EntityPropertyFlags|PROP_DERIVED_26}</td><td>Particle spin flag.</td></tr>
- *          <tr><td>PROP_SPIN_START</td><td>{@link EntityPropertyFlags|PROP_DERIVED_27}</td><td>Spin start flag.</td></tr>
- *          <tr><td>PROP_SPIN_FINISH</td><td>{@link EntityPropertyFlags|PROP_DERIVED_28}</td><td>Spin finish flag.</td></tr>
- *          <tr><td>PROP_SPIN_SPREAD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_29}</td><td>Spin spread flag.</td></tr>
- *          <tr><td>PROP_PARTICLE_ROTATE_WITH_ENTITY</td><td>{@link EntityPropertyFlags|PROP_DERIVED_30}</td><td>Particle rotate
- *          with entity flag.</td></tr>
- *          <tr><td>PROP_MODEL_URL</td><td>{@link EntityPropertyFlags|PROP_DERIVED_0}</td><td>Model url flag. First Model
- *          entity-specific property.<br />
- *          {@link ModelEntityItem|ModelEntity}</td></tr>
- *          <tr><td>PROP_MODEL_SCALE</td><td>{@link EntityPropertyFlags|PROP_DERIVED_1}</td><td>Model scale flag.</td></tr>
- *          <tr><td>PROP_JOINT_ROTATIONS_SET</td><td>{@link EntityPropertyFlags|PROP_DERIVED_2}</td><td>Joint rotations set
- *          flag.</td></tr>
- *          <tr><td>PROP_JOINT_ROTATIONS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_3}</td><td>Joint rotations flag.</td>
- *          </tr>
- *          <tr><td>PROP_JOINT_TRANSLATIONS_SET</td><td>{@link EntityPropertyFlags|PROP_DERIVED_4}</td><td>Joint translations
- *          set flag.</td></tr>
- *          <tr><td>PROP_JOINT_TRANSLATIONS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_5}</td><td>Joint translations flag.
- *          </td></tr>
- *          <tr><td>PROP_RELAY_PARENT_JOINTS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_6}</td><td>Relay parent joints
- *          flag.</td></tr>
- *          <tr><td>PROP_GROUP_CULLED</td><td>{@link EntityPropertyFlags|PROP_DERIVED_7}</td><td>Group culled flag.</td></tr>
- *          <tr><td>PROP_BLENDSHAPE_COEFFICIENTS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_8}</td><td>Blendshape
- *          coefficients flag.</td></tr>
- *          <tr><td>PROP_USE_ORIGINAL_PIVOT</td><td>{@link EntityPropertyFlags|PROP_DERIVED_9}</td><td>Use original pivot flag.
- *          </td></tr>
- *          <tr><td>PROP_ANIMATION_URL</td><td>{@link EntityPropertyFlags|PROP_DERIVED_10}</td><td>Animation url flag.</td></tr>
- *          <tr><td>PROP_ANIMATION_ALLOW_TRANSLATION</td><td>{@link EntityPropertyFlags|PROP_DERIVED_11}</td><td>Animation allow
- *          translation flag.</td></tr>
- *          <tr><td>PROP_ANIMATION_FPS</td><td>{@link EntityPropertyFlags|PROP_DERIVED_12}</td><td>Animation fps flag.</td></tr>
- *          <tr><td>PROP_ANIMATION_FRAME_INDEX</td><td>{@link EntityPropertyFlags|PROP_DERIVED_13}</td><td>Animation frame index
- *          flag.</td></tr>
- *          <tr><td>PROP_ANIMATION_PLAYING</td><td>{@link EntityPropertyFlags|PROP_DERIVED_14}</td><td>Animation playing flag.
- *          </td></tr>
- *          <tr><td>PROP_ANIMATION_LOOP</td><td>{@link EntityPropertyFlags|PROP_DERIVED_15}</td><td>Animation loop flag.</td>
- *          </tr>
- *          <tr><td>PROP_ANIMATION_FIRST_FRAME</td><td>{@link EntityPropertyFlags|PROP_DERIVED_16}</td><td>Animation first frame
- *          flag.</td></tr>
- *          <tr><td>PROP_ANIMATION_LAST_FRAME</td><td>{@link EntityPropertyFlags|PROP_DERIVED_17}</td><td>Animation last frame
- *          flag.</td></tr>
- *          <tr><td>PROP_ANIMATION_HOLD</td><td>{@link EntityPropertyFlags|PROP_DERIVED_18}</td><td>Animation hold flag.</td>
- *          <tr><td>PROP_SHAPE</td><td>{@link EntityPropertyFlags|PROP_DERIVED_0}</td><td>Shape flag.</td>
- *          </tr>
- *      </tbody>
- *  </table>
- *  @typedef {number} EntityPropertyFlags
+ *  The <code>EntityPropertyList</code> namespace provides the positions of the flags in {@link PropertyFlags}.
+ *  @namespace EntityPropertyList
+ *  @property {number} PROP_PAGED_PROPERTY - <code>0</code> - Paged property flag.
+ *  @property {number} PROP_CUSTOM_PROPERTIES_INCLUDED - <code>1</code> - Custom properties included flag.
+ *  @property {number} PROP_SIMULATION_OWNER - <code>2</code> - Simulation owner flag.
+ *  @property {number} PROP_PARENT_ID - <code>3</code> - Parent id flag.
+ *  @property {number} PROP_PARENT_JOINT_INDEX - <code>4</code> - Parent joint index flag.
+ *  @property {number} PROP_VISIBLE - <code>5</code> - Visible flag.
+ *  @property {number} PROP_NAME - <code>6</code> - Name flag.
+ *  @property {number} PROP_LOCKED - <code>7</code> - Locked flag.
+ *  @property {number} PROP_USER_DATA - <code>8</code> - User data flag.
+ *  @property {number} PROP_PRIVATE_USER_DATA - <code>9</code> - Private user data flag.
+ *  @property {number} PROP_HREF - <code>10</code> - Href flag.
+ *  @property {number} PROP_DESCRIPTION - <code>11</code> - Description flag.
+ *  @property {number} PROP_POSITION - <code>12</code> - Position flag.
+ *  @property {number} PROP_DIMENSIONS - <code>13</code> - Dimensions flag.
+ *  @property {number} PROP_ROTATION - <code>14</code> - Rotation flag.
+ *  @property {number} PROP_REGISTRATION_POINT - <code>15</code> - Registration point flag.
+ *  @property {number} PROP_CREATED - <code>16</code> - Created flag.
+ *  @property {number} PROP_LAST_EDITED_BY - <code>17</code> - Last edited by flag.
+ *  @property {number} PROP_ENTITY_HOST_TYPE - <code>18</code> - Entity host type flag.
+ *  @property {number} PROP_OWNING_AVATAR_ID - <code>19</code> - Owning avatar id flag.
+ *  @property {number} PROP_QUERY_AA_CUBE - <code>20</code> - Query aa cube flag.
+ *  @property {number} PROP_CAN_CAST_SHADOW - <code>21</code> - Can cast shadow flag.
+ *  @property {number} PROP_VISIBLE_IN_SECONDARY_CAMERA - <code>22</code> - Visible in secondary camera flag.
+ *  @property {number} PROP_RENDER_LAYER - <code>23</code> - Render layer flag.
+ *  @property {number} PROP_PRIMITIVE_MODE - <code>24</code> - Primitive mode flag.
+ *  @property {number} PROP_IGNORE_PICK_INTERSECTION - <code>25</code> - Ignore pick intersection flag.
+ *  @property {number} PROP_RENDER_WITH_ZONES - <code>26</code> - Render with zones flag.
+ *  @property {number} PROP_BILLBOARD_MODE - <code>27</code> - Billboard mode flag.
+ *  @property {number} PROP_GRAB_GRABBABLE - <code>28</code> - Grab grabbable flag.
+ *  @property {number} PROP_GRAB_KINEMATIC - <code>29</code> - Grab kinematic flag.
+ *  @property {number} PROP_GRAB_FOLLOWS_CONTROLLER - <code>30</code> - Grab follows controller flag.
+ *  @property {number} PROP_GRAB_TRIGGERABLE - <code>31</code> - Grab triggerable flag.
+ *  @property {number} PROP_GRAB_EQUIPPABLE - <code>32</code> - Grab equippable flag.
+ *  @property {number} PROP_GRAB_DELEGATE_TO_PARENT - <code>33</code> - Grab delegate to parent flag.
+ *  @property {number} PROP_GRAB_LEFT_EQUIPPABLE_POSITION_OFFSET - <code>34</code> - Grab left equippable position offset flag.
+ *  @property {number} PROP_GRAB_LEFT_EQUIPPABLE_ROTATION_OFFSET - <code>35</code> - Grab left equippable rotation offset flag.
+ *  @property {number} PROP_GRAB_RIGHT_EQUIPPABLE_POSITION_OFFSET - <code>36</code> - Grab right equippable position offset
+ *      flag.
+ *  @property {number} PROP_GRAB_RIGHT_EQUIPPABLE_ROTATION_OFFSET - <code>37</code> - Grab right equippable rotation offset
+ *      flag.
+ *  @property {number} PROP_GRAB_EQUIPPABLE_INDICATOR_URL - <code>38</code> - Grab equippable indicator url flag.
+ *  @property {number} PROP_GRAB_EQUIPPABLE_INDICATOR_SCALE - <code>39</code> - Grab equippable indicator scale flag.
+ *  @property {number} PROP_GRAB_EQUIPPABLE_INDICATOR_OFFSET - <code>40</code> - Grab equippable indicator offset flag.
+ *  @property {number} PROP_DENSITY - <code>41</code> - Density flag.
+ *  @property {number} PROP_VELOCITY - <code>42</code> - Velocity flag.
+ *  @property {number} PROP_ANGULAR_VELOCITY - <code>43</code> - Angular velocity flag.
+ *  @property {number} PROP_GRAVITY - <code>44</code> - Gravity flag.
+ *  @property {number} PROP_ACCELERATION - <code>45</code> - Acceleration flag.
+ *  @property {number} PROP_DAMPING - <code>46</code> - Damping flag.
+ *  @property {number} PROP_ANGULAR_DAMPING - <code>47</code> - Angular damping flag.
+ *  @property {number} PROP_RESTITUTION - <code>48</code> - Restitution flag.
+ *  @property {number} PROP_FRICTION - <code>49</code> - Friction flag.
+ *  @property {number} PROP_LIFETIME - <code>50</code> - Lifetime flag.
+ *  @property {number} PROP_COLLISIONLESS - <code>51</code> - Collisionless flag.
+ *  @property {number} PROP_COLLISION_MASK - <code>52</code> - Collision mask flag.
+ *  @property {number} PROP_DYNAMIC - <code>53</code> - Dynamic flag.
+ *  @property {number} PROP_COLLISION_SOUND_URL - <code>54</code> - Collision sound url flag.
+ *  @property {number} PROP_ACTION_DATA - <code>55</code> - Action data flag.
+ *  @property {number} PROP_CLONEABLE - <code>56</code> - Cloneable flag.
+ *  @property {number} PROP_CLONE_LIFETIME - <code>57</code> - Clone lifetime flag.
+ *  @property {number} PROP_CLONE_LIMIT - <code>58</code> - Clone limit flag.
+ *  @property {number} PROP_CLONE_DYNAMIC - <code>59</code> - Clone dynamic flag.
+ *  @property {number} PROP_CLONE_AVATAR_ENTITY - <code>60</code> - Clone avatar entity flag.
+ *  @property {number} PROP_CLONE_ORIGIN_ID - <code>61</code> - Clone origin id flag.
+ *  @property {number} PROP_SCRIPT - <code>62</code> - Script flag.
+ *  @property {number} PROP_SCRIPT_TIMESTAMP - <code>63</code> - Script timestamp flag.
+ *  @property {number} PROP_SERVER_SCRIPTS - <code>64</code> - Server scripts flag.
+ *  @property {number} PROP_ITEM_NAME - <code>65</code> - Item name flag.
+ *  @property {number} PROP_ITEM_DESCRIPTION - <code>66</code> - Item description flag.
+ *  @property {number} PROP_ITEM_CATEGORIES - <code>67</code> - Item categories flag.
+ *  @property {number} PROP_ITEM_ARTIST - <code>68</code> - Item artist flag.
+ *  @property {number} PROP_ITEM_LICENSE - <code>69</code> - Item license flag.
+ *  @property {number} PROP_LIMITED_RUN - <code>70</code> - Limited run flag.
+ *  @property {number} PROP_MARKETPLACE_ID - <code>71</code> - Marketplace id flag.
+ *  @property {number} PROP_EDITION_NUMBER - <code>72</code> - Edition number flag.
+ *  @property {number} PROP_ENTITY_INSTANCE_NUMBER - <code>73</code> - Entity instance number flag.
+ *  @property {number} PROP_CERTIFICATE_ID - <code>74</code> - Certificate id flag.
+ *  @property {number} PROP_CERTIFICATE_TYPE - <code>75</code> - Certificate type flag.
+ *  @property {number} PROP_STATIC_CERTIFICATE_VERSION - <code>76</code> - Static certificate version flag.
+ *  @property {number} PROP_LOCAL_POSITION - <code>77</code> - Local position flag.
+ *  @property {number} PROP_LOCAL_ROTATION - <code>78</code> - Local rotation flag.
+ *  @property {number} PROP_LOCAL_VELOCITY - <code>79</code> - Local velocity flag.
+ *  @property {number} PROP_LOCAL_ANGULAR_VELOCITY - <code>80</code> - Local angular velocity flag.
+ *  @property {number} PROP_LOCAL_DIMENSIONS - <code>81</code> - Local dimensions flag.
+ *  @property {number} PROP_SHAPE_TYPE - <code>82</code> - Shape type flag.
+ *  @property {number} PROP_COMPOUND_SHAPE_URL - <code>83</code> - Compound shape url flag.
+ *  @property {number} PROP_COLOR - <code>84</code> - Color flag.
+ *  @property {number} PROP_ALPHA - <code>85</code> - Alpha flag.
+ *  @property {number} PROP_PULSE_MIN - <code>86</code> - Pulse min flag.
+ *  @property {number} PROP_PULSE_MAX - <code>87</code> - Pulse max flag.
+ *  @property {number} PROP_PULSE_PERIOD - <code>88</code> - Pulse period flag.
+ *  @property {number} PROP_PULSE_COLOR_MODE - <code>89</code> - Pulse color mode flag.
+ *  @property {number} PROP_PULSE_ALPHA_MODE - <code>90</code> - Pulse alpha mode flag.
+ *  @property {number} PROP_TEXTURES - <code>91</code> - Textures flag.
+ *  @property {number} PROP_DERIVED_0 - <code>92</code> - Derived 0 flag.
+ *  @property {number} PROP_DERIVED_1 - <code>93</code> - Derived 1 flag.
+ *  @property {number} PROP_DERIVED_2 - <code>94</code> - Derived 2 flag.
+ *  @property {number} PROP_DERIVED_3 - <code>95</code> - Derived 3 flag.
+ *  @property {number} PROP_DERIVED_4 - <code>96</code> - Derived 4 flag.
+ *  @property {number} PROP_DERIVED_5 - <code>97</code> - Derived 5 flag.
+ *  @property {number} PROP_DERIVED_6 - <code>98</code> - Derived 6 flag.
+ *  @property {number} PROP_DERIVED_7 - <code>99</code> - Derived 7 flag.
+ *  @property {number} PROP_DERIVED_8 - <code>100</code> - Derived 8 flag.
+ *  @property {number} PROP_DERIVED_9 - <code>101</code> - Derived 9 flag.
+ *  @property {number} PROP_DERIVED_10 - <code>102</code> - Derived 10 flag.
+ *  @property {number} PROP_DERIVED_11 - <code>103</code> - Derived 11 flag.
+ *  @property {number} PROP_DERIVED_12 - <code>104</code> - Derived 12 flag.
+ *  @property {number} PROP_DERIVED_13 - <code>105</code> - Derived 13 flag.
+ *  @property {number} PROP_DERIVED_14 - <code>106</code> - Derived 14 flag.
+ *  @property {number} PROP_DERIVED_15 - <code>107</code> - Derived 15 flag.
+ *  @property {number} PROP_DERIVED_16 - <code>108</code> - Derived 16 flag.
+ *  @property {number} PROP_DERIVED_17 - <code>109</code> - Derived 17 flag.
+ *  @property {number} PROP_DERIVED_18 - <code>110</code> - Derived 18 flag.
+ *  @property {number} PROP_DERIVED_19 - <code>111</code> - Derived 19 flag.
+ *  @property {number} PROP_DERIVED_20 - <code>112</code> - Derived 20 flag.
+ *  @property {number} PROP_DERIVED_21 - <code>113</code> - Derived 21 flag.
+ *  @property {number} PROP_DERIVED_22 - <code>114</code> - Derived 22 flag.
+ *  @property {number} PROP_DERIVED_23 - <code>115</code> - Derived 23 flag.
+ *  @property {number} PROP_DERIVED_24 - <code>116</code> - Derived 24 flag.
+ *  @property {number} PROP_DERIVED_25 - <code>117</code> - Derived 25 flag.
+ *  @property {number} PROP_DERIVED_26 - <code>118</code> - Derived 26 flag.
+ *  @property {number} PROP_DERIVED_27 - <code>119</code> - Derived 27 flag.
+ *  @property {number} PROP_DERIVED_28 - <code>120</code> - Derived 28 flag.
+ *  @property {number} PROP_DERIVED_29 - <code>121</code> - Derived 29 flag.
+ *  @property {number} PROP_DERIVED_30 - <code>122</code> - Derived 30 flag.
+ *  @property {number} PROP_DERIVED_31 - <code>123</code> - Derived 31 flag.
+ *  @property {number} PROP_DERIVED_32 - <code>124</code> - Derived 32 flag.
+ *  @property {number} PROP_DERIVED_33 - <code>125</code> - Derived 33 flag.
+ *  @property {number} PROP_DERIVED_34 - <code>126</code> - Derived 34 flag.
+ *  @property {number} PROP_AFTER_LAST_ITEM - <code>127</code> - After last item flag.
+ *  @property {number} PROP_MAX_PARTICLES - <code>{@link EntityPropertyList|PROP_DERIVED_0}</code> - Max particles flag. First
+ *      ParticleEffect entity-specific property.
+ *  @property {number} PROP_LIFESPAN - <code>{@link EntityPropertyList|PROP_DERIVED_1}</code> - Lifespan flag.
+ *  @property {number} PROP_EMITTING_PARTICLES - <code>{@link EntityPropertyList|PROP_DERIVED_2}</code> - Emitting_particles
+ *      flag.
+ *  @property {number} PROP_EMIT_RATE - <code>{@link EntityPropertyList|PROP_DERIVED_3}</code> - Emit rate flag.
+ *  @property {number} PROP_EMIT_SPEED - <code>{@link EntityPropertyList|PROP_DERIVED_4}</code> - Emit speed flag.
+ *  @property {number} PROP_SPEED_SPREAD - <code>{@link EntityPropertyList|PROP_DERIVED_5}</code> - Speed spread flag.
+ *  @property {number} PROP_EMIT_ORIENTATION - <code>{@link EntityPropertyList|PROP_DERIVED_6}</code> - Emit orientation flag.
+ *  @property {number} PROP_EMIT_DIMENSIONS - <code>{@link EntityPropertyList|PROP_DERIVED_7}</code> - Emit dimensions flag.
+ *  @property {number} PROP_ACCELERATION_SPREAD - <code>{@link EntityPropertyList|PROP_DERIVED_8}</code> - Acceleration spread
+ *      flag.
+ *  @property {number} PROP_POLAR_START - <code>{@link EntityPropertyList|PROP_DERIVED_9}</code> - Polar start flag.
+ *  @property {number} PROP_POLAR_FINISH - <code>{@link EntityPropertyList|PROP_DERIVED_10}</code> - Polar finish flag.
+ *  @property {number} PROP_AZIMUTH_START - <code>{@link EntityPropertyList|PROP_DERIVED_11}</code> - Azimuth start flag.
+ *  @property {number} PROP_AZIMUTH_FINISH - <code>{@link EntityPropertyList|PROP_DERIVED_12}</code> - Azimuth finish flag.
+ *  @property {number} PROP_EMIT_RADIUS_START - <code>{@link EntityPropertyList|PROP_DERIVED_13}</code> - Emit radius start
+ *      flag.
+ *  @property {number} PROP_EMIT_ACCELERATION - <code>{@link EntityPropertyList|PROP_DERIVED_14}</code> - Emit acceleration
+ *      flag.
+ *  @property {number} PROP_PARTICLE_RADIUS - <code>{@link EntityPropertyList|PROP_DERIVED_15}</code> - Particle radius flag.
+ *  @property {number} PROP_RADIUS_SPREAD - <code>{@link EntityPropertyList|PROP_DERIVED_16}</code> - Radius spread flag.
+ *  @property {number} PROP_RADIUS_START - <code>{@link EntityPropertyList|PROP_DERIVED_17}</code> - Radius start flag.
+ *  @property {number} PROP_RADIUS_FINISH - <code>{@link EntityPropertyList|PROP_DERIVED_18}</code> - Radius finish flag.
+ *  @property {number} PROP_COLOR_SPREAD - <code>{@link EntityPropertyList|PROP_DERIVED_19}</code> - Color spread flag.
+ *  @property {number} PROP_COLOR_START - <code>{@link EntityPropertyList|PROP_DERIVED_20}</code> - Color start flag.
+ *  @property {number} PROP_COLOR_FINISH - <code>{@link EntityPropertyList|PROP_DERIVED_21}</code> - Color finish flag.
+ *  @property {number} PROP_ALPHA_SPREAD - <code>{@link EntityPropertyList|PROP_DERIVED_22}</code> - Alpha spread flag.
+ *  @property {number} PROP_ALPHA_START - <code>{@link EntityPropertyList|PROP_DERIVED_23}</code> - Alpha start flag.
+ *  @property {number} PROP_ALPHA_FINISH - <code>{@link EntityPropertyList|PROP_DERIVED_24}</code> - Alpha finish flag.
+ *  @property {number} PROP_EMITTER_SHOULD_TRAIL - <code>{@link EntityPropertyList|PROP_DERIVED_25}</code> - Emitter should
+ *      trail flag.
+ *  @property {number} PROP_PARTICLE_SPIN - <code>{@link EntityPropertyList|PROP_DERIVED_26}</code> - Particle spin flag.
+ *  @property {number} PROP_SPIN_START - <code>{@link EntityPropertyList|PROP_DERIVED_27}</code> - Spin start flag.
+ *  @property {number} PROP_SPIN_FINISH - <code>{@link EntityPropertyList|PROP_DERIVED_28}</code> - Spin finish flag.
+ *  @property {number} PROP_SPIN_SPREAD - <code>{@link EntityPropertyList|PROP_DERIVED_29}</code> - Spin spread flag.
+ *  @property {number} PROP_PARTICLE_ROTATE_WITH_ENTITY - <code>{@link EntityPropertyList|PROP_DERIVED_30}</code> - Particle
+ *      rotate with entity flag.
+ *  @property {number} PROP_MODEL_URL - <code>{@link EntityPropertyList|PROP_DERIVED_0}</code> - Model url flag. First
+ *      {@link ModelEntityItem|ModelEntity}-specific property.
+ *  @property {number} PROP_MODEL_SCALE - <code>{@link EntityPropertyList|PROP_DERIVED_1}</code> - Model scale flag.
+ *  @property {number} PROP_JOINT_ROTATIONS_SET - <code>{@link EntityPropertyList|PROP_DERIVED_2}</code> - Joint rotations set
+ *      flag.
+ *  @property {number} PROP_JOINT_ROTATIONS - <code>{@link EntityPropertyList|PROP_DERIVED_3}</code> - Joint rotations flag.
+ *  @property {number} PROP_JOINT_TRANSLATIONS_SET - <code>{@link EntityPropertyList|PROP_DERIVED_4}</code> - Joint translations
+ *      set flag.
+ *  @property {number} PROP_JOINT_TRANSLATIONS - <code>{@link EntityPropertyList|PROP_DERIVED_5}</code> - Joint translations
+ *      flag.
+ *  @property {number} PROP_RELAY_PARENT_JOINTS - <code>{@link EntityPropertyList|PROP_DERIVED_6}</code> - Relay parent joints
+ *      flag.
+ *  @property {number} PROP_GROUP_CULLED - <code>{@link EntityPropertyList|PROP_DERIVED_7}</code> - Group culled flag.
+ *  @property {number} PROP_BLENDSHAPE_COEFFICIENTS - <code>{@link EntityPropertyList|PROP_DERIVED_8}</code> - Blendshape
+ *      coefficients flag.
+ *  @property {number} PROP_USE_ORIGINAL_PIVOT - <code>{@link EntityPropertyList|PROP_DERIVED_9}</code> - Use original pivot
+ *      flag.
+ *  @property {number} PROP_ANIMATION_URL - <code>{@link EntityPropertyList|PROP_DERIVED_10}</code> - Animation url flag.
+ *  @property {number} PROP_ANIMATION_ALLOW_TRANSLATION - <code>{@link EntityPropertyList|PROP_DERIVED_11}</code> - Animation
+ *      allow translation flag.
+ *  @property {number} PROP_ANIMATION_FPS - <code>{@link EntityPropertyList|PROP_DERIVED_12}</code> - Animation fps flag.
+ *  @property {number} PROP_ANIMATION_FRAME_INDEX - <code>{@link EntityPropertyList|PROP_DERIVED_13}</code> - Animation frame
+ *      index flag.
+ *  @property {number} PROP_ANIMATION_PLAYING - <code>{@link EntityPropertyList|PROP_DERIVED_14}</code> - Animation playing
+ *      flag.
+ *  @property {number} PROP_ANIMATION_LOOP - <code>{@link EntityPropertyList|PROP_DERIVED_15}</code> - Animation loop flag.
+ *  @property {number} PROP_ANIMATION_FIRST_FRAME - <code>{@link EntityPropertyList|PROP_DERIVED_16}</code> - Animation first
+ *      frame flag.
+ *  @property {number} PROP_ANIMATION_LAST_FRAME - <code>{@link EntityPropertyList|PROP_DERIVED_17}</code> - Animation last
+ *      frame flag.
+ *  @property {number} PROP_ANIMATION_HOLD - <code>{@link EntityPropertyList|PROP_DERIVED_18}</code> - Animation hold flag.
+ *  @property {number} PROP_SHAPE - <code>{@link EntityPropertyList|PROP_DERIVED_0}</code> - Shape flag.
  */
-enum EntityPropertyFlags {
-    // C++  EntityPropertyFlags.h
+enum EntityPropertyList {
+    // C++  EntityPropertyList
 
     PROP_PAGED_PROPERTY,
     PROP_CUSTOM_PROPERTIES_INCLUDED,
@@ -592,4 +575,4 @@ enum EntityPropertyFlags {
     PROP_MINOR_TICK_MARKS_COLOR = PROP_DERIVED_18
 }
 
-export { EntityPropertyFlags };
+export { EntityPropertyList };

--- a/src/domain/entities/EntityPropertyFlags.ts
+++ b/src/domain/entities/EntityPropertyFlags.ts
@@ -593,4 +593,5 @@ class EntityPropertyFlags extends PropertyFlags {
     // C++  typedef PropertyFlags<EntityPropertyList> EntityPropertyFlags
 }
 
-export { EntityPropertyList, EntityPropertyFlags };
+export default EntityPropertyFlags;
+export { EntityPropertyList };

--- a/src/domain/entities/EntityPropertyFlags.ts
+++ b/src/domain/entities/EntityPropertyFlags.ts
@@ -217,6 +217,7 @@ import PropertyFlags from "../shared/PropertyFlags";
  */
 enum EntityPropertyList {
     // C++  EntityPropertyList
+    //      EntityPropertyList PROP_LAST_ITEM = (EntityPropertyList)(PROP_AFTER_LAST_ITEM - 1);
 
     PROP_PAGED_PROPERTY,
     PROP_CUSTOM_PROPERTIES_INCLUDED,
@@ -574,7 +575,10 @@ enum EntityPropertyList {
     PROP_MAJOR_TICK_MARKS_LENGTH = PROP_DERIVED_15,
     PROP_MINOR_TICK_MARKS_LENGTH = PROP_DERIVED_16,
     PROP_MAJOR_TICK_MARKS_COLOR = PROP_DERIVED_17,
-    PROP_MINOR_TICK_MARKS_COLOR = PROP_DERIVED_18
+    PROP_MINOR_TICK_MARKS_COLOR = PROP_DERIVED_18,
+
+    // Last item
+    PROP_LAST_ITEM = PROP_AFTER_LAST_ITEM - 1
 }
 
 /*@devdoc

--- a/src/domain/entities/EntityPropertyFlags.ts
+++ b/src/domain/entities/EntityPropertyFlags.ts
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import PropertyFlags from "../shared/PropertyFlags";
+
 /*@devdoc
  *  The <code>EntityPropertyList</code> namespace provides the positions of the flags in {@link PropertyFlags}.
  *  @namespace EntityPropertyList
@@ -575,4 +577,16 @@ enum EntityPropertyList {
     PROP_MINOR_TICK_MARKS_COLOR = PROP_DERIVED_18
 }
 
-export { EntityPropertyList };
+/*@devdoc
+ *  The <code>EntityPropertyFlags</code> provides facilities to decode, set and get entity property flags per the
+ *  {@link EntityPropertyList} values.
+ *
+ *  <p>C++ <code>typedef PropertyFlags<EntityPropertyList> EntityPropertyFlags</code></p>
+ *  @class EntityPropertyFlags
+ *  @extends PropertyFlags
+ */
+class EntityPropertyFlags extends PropertyFlags {
+    // C++  typedef PropertyFlags<EntityPropertyList> EntityPropertyFlags
+}
+
+export { EntityPropertyList, EntityPropertyFlags };

--- a/src/domain/entities/EntityTypes.ts
+++ b/src/domain/entities/EntityTypes.ts
@@ -10,7 +10,7 @@
 //
 
 /*@sdkdoc
- *  The <code>EntityType</code> namespace provides types for entities.
+ *  The <code>EntityType</code> namespace enumerates entity types.
  *  @namespace EntityType
  *  @property {number} Unknown - <code>0</code> - Default entity type.
  *  @property {number} Box - <code>1</code> - A rectangular prism. This is a synonym of <code>Shape</code> for the case where

--- a/src/domain/entities/GizmoEntityItem.ts
+++ b/src/domain/entities/GizmoEntityItem.ts
@@ -10,8 +10,7 @@
 //
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import RingGizmoPropertyGroup from "./RingGizmoPropertyGroup";
 
 
@@ -30,7 +29,7 @@ type GizmoEntitySubclassData = {
 class GizmoEntityItem {
     // C++  class GizmoEntityItem : public EntityItem
 
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): GizmoEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): GizmoEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int GizmoEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/GizmoEntityItem.ts
+++ b/src/domain/entities/GizmoEntityItem.ts
@@ -11,7 +11,7 @@
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import RingGizmoPropertyGroup from "./RingGizmoPropertyGroup";
 
 
@@ -39,7 +39,7 @@ class GizmoEntityItem {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GIZMO_TYPE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GIZMO_TYPE)) {
             // WEBRTC TODO: Read gizmoType property.
             dataPosition += 4;
         }

--- a/src/domain/entities/GridEntityItem.ts
+++ b/src/domain/entities/GridEntityItem.ts
@@ -11,7 +11,7 @@
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -39,12 +39,12 @@ class GridEntityItem {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             // WEBRTC TODO: Read color property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA)) {
             // WEBRTC TODO: Read alpha property.
             dataPosition += 4;
         }
@@ -53,17 +53,17 @@ class GridEntityItem {
         // Ignore deprecated pulse property.
         dataPosition += pulseProperties.bytesRead;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRID_FOLLOW_CAMERA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRID_FOLLOW_CAMERA)) {
             // WEBRTC TODO: Read gridFollowCamera property.
             dataPosition += 1;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MAJOR_GRID_EVERY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MAJOR_GRID_EVERY)) {
             // WEBRTC TODO: Read majorGridEvery property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MINOR_GRID_EVERY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MINOR_GRID_EVERY)) {
             // WEBRTC TODO: Read minorGridEvery property.
             dataPosition += 4;
         }

--- a/src/domain/entities/GridEntityItem.ts
+++ b/src/domain/entities/GridEntityItem.ts
@@ -10,8 +10,7 @@
 //
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -30,7 +29,7 @@ type GridEntitySubclassData = {
 class GridEntityItem {
     // C++  class GridEntityItem : public EntityItem
 
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): GridEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): GridEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int GridEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/HazePropertyGroup.ts
+++ b/src/domain/entities/HazePropertyGroup.ts
@@ -12,7 +12,7 @@
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type HazeProperties = {
@@ -100,13 +100,13 @@ class HazePropertyGroup {
         let dataPosition = position;
 
         let range: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_RANGE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_RANGE)) {
             range = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -116,7 +116,7 @@ class HazePropertyGroup {
         }
 
         let glareColor: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_GLARE_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_GLARE_COLOR)) {
             glareColor = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -126,57 +126,57 @@ class HazePropertyGroup {
         }
 
         let enableGlare: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_ENABLE_GLARE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_ENABLE_GLARE)) {
             enableGlare = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let glareAngle: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_GLARE_ANGLE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_GLARE_ANGLE)) {
             glareAngle = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let altitudeEffect: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_ALTITUDE_EFFECT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_ALTITUDE_EFFECT)) {
             altitudeEffect = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let ceiling: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_CEILING)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_CEILING)) {
             ceiling = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let base: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_BASE_REF)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_BASE_REF)) {
             base = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let backgroundBlend: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_BACKGROUND_BLEND)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_BACKGROUND_BLEND)) {
             backgroundBlend = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             // WEBRTC TODO: Read hazeBackgroundBlend property.
             dataPosition += 4;
         }
 
         let attenuateKeyLight: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_ATTENUATE_KEYLIGHT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_ATTENUATE_KEYLIGHT)) {
             attenuateKeyLight = Boolean(data.getUint8(dataPosition));
             // WEBRTC TODO: Read hazeAttenuateKeylight property.
             dataPosition += 1;
         }
 
         let keyLightRange: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_KEYLIGHT_RANGE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_KEYLIGHT_RANGE)) {
             keyLightRange = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let keyLightAltitude: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_KEYLIGHT_ALTITUDE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_KEYLIGHT_ALTITUDE)) {
             keyLightAltitude = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }

--- a/src/domain/entities/HazePropertyGroup.ts
+++ b/src/domain/entities/HazePropertyGroup.ts
@@ -11,8 +11,7 @@
 
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type HazeProperties = {
@@ -90,7 +89,7 @@ class HazePropertyGroup {
      *  @returns {HazePropertyGroupSubclassData} The Zone entity's haze properties and the number of bytes read.
      */
     static readEntitySubclassDataFromBuffer(data: DataView, position: number,
-        propertyFlags: PropertyFlags): HazePropertyGroupSubclassData {
+        propertyFlags: EntityPropertyFlags): HazePropertyGroupSubclassData {
         // C++  int HazePropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/ImageEntityItem.ts
+++ b/src/domain/entities/ImageEntityItem.ts
@@ -14,7 +14,7 @@ import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
 import { rect } from "../shared/Rect";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -95,7 +95,7 @@ class ImageEntityItem {
         const textDecoder = new TextDecoder();
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -105,7 +105,7 @@ class ImageEntityItem {
         }
 
         let alpha: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA)) {
             alpha = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
@@ -115,7 +115,7 @@ class ImageEntityItem {
         dataPosition += pulseProperties.bytesRead;
 
         let imageURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_IMAGE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_IMAGE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -127,19 +127,19 @@ class ImageEntityItem {
         }
 
         let emissive: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMISSIVE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMISSIVE)) {
             emissive = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let keepAspectRatio: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEEP_ASPECT_RATIO)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEEP_ASPECT_RATIO)) {
             keepAspectRatio = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let subImage: rect | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SUB_IMAGE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SUB_IMAGE)) {
             subImage = {
                 x: data.getUint32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getUint32(dataPosition + 4, UDT.LITTLE_ENDIAN),

--- a/src/domain/entities/ImageEntityItem.ts
+++ b/src/domain/entities/ImageEntityItem.ts
@@ -12,9 +12,8 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
 import { rect } from "../shared/Rect";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -83,7 +82,7 @@ class ImageEntityItem {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {ImageEntitySubclassData} The Image entity properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): ImageEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): ImageEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int ImageEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/KeyLightPropertyGroup.ts
+++ b/src/domain/entities/KeyLightPropertyGroup.ts
@@ -11,9 +11,8 @@
 
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
 import type { vec3 } from "../shared/Vec3";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type KeyLightProperties = {
@@ -73,7 +72,7 @@ class KeyLightPropertyGroup {
      *  @returns {KeyLightPropertyGroupSubclassData} The Zone entity's key light properties and the number of bytes read.
      */
     static readEntitySubclassDataFromBuffer(data: DataView, position: number,
-        propertyFlags: PropertyFlags): KeyLightPropertyGroupSubclassData {
+        propertyFlags: EntityPropertyFlags): KeyLightPropertyGroupSubclassData {
         // C++  int KeyLightPropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/KeyLightPropertyGroup.ts
+++ b/src/domain/entities/KeyLightPropertyGroup.ts
@@ -13,7 +13,7 @@ import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
 import type { vec3 } from "../shared/Vec3";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type KeyLightProperties = {
@@ -83,7 +83,7 @@ class KeyLightPropertyGroup {
         let dataPosition = position;
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEYLIGHT_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEYLIGHT_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -93,13 +93,13 @@ class KeyLightPropertyGroup {
         }
 
         let intensity: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEYLIGHT_INTENSITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEYLIGHT_INTENSITY)) {
             intensity = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let direction: vec3 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEYLIGHT_DIRECTION)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEYLIGHT_DIRECTION)) {
             direction = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -109,19 +109,19 @@ class KeyLightPropertyGroup {
         }
 
         let castShadows: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEYLIGHT_CAST_SHADOW)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEYLIGHT_CAST_SHADOW)) {
             castShadows = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let shadowBias: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEYLIGHT_SHADOW_BIAS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEYLIGHT_SHADOW_BIAS)) {
             shadowBias = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let shadowMaxDistance: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEYLIGHT_SHADOW_MAX_DISTANCE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEYLIGHT_SHADOW_MAX_DISTANCE)) {
             shadowMaxDistance = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }

--- a/src/domain/entities/LightEntityItem.ts
+++ b/src/domain/entities/LightEntityItem.ts
@@ -12,8 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type LightEntitySubclassProperties = {
@@ -75,7 +74,7 @@ class LightEntityItem {
      *  @returns {LightEntitySubclassData} The Light entity properties and the number of bytes read.
      */
     static readEntitySubclassDataFromBuffer(data: DataView, position: number,
-        propertyFlags: PropertyFlags): LightEntitySubclassData {
+        propertyFlags: EntityPropertyFlags): LightEntitySubclassData {
         // C++  int LightEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/LightEntityItem.ts
+++ b/src/domain/entities/LightEntityItem.ts
@@ -13,7 +13,7 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type LightEntitySubclassProperties = {
@@ -85,7 +85,7 @@ class LightEntityItem {
         let dataPosition = position;
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -95,31 +95,31 @@ class LightEntityItem {
         }
 
         let isSpotlight: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_IS_SPOTLIGHT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_IS_SPOTLIGHT)) {
             isSpotlight = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let intensity: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INTENSITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INTENSITY)) {
             intensity = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let exponent: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EXPONENT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EXPONENT)) {
             exponent = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let cutoff: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CUTOFF)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CUTOFF)) {
             cutoff = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let falloffRadius: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_FALLOFF_RADIUS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_FALLOFF_RADIUS)) {
             falloffRadius = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }

--- a/src/domain/entities/LineEntityItem.ts
+++ b/src/domain/entities/LineEntityItem.ts
@@ -11,8 +11,7 @@
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 // WEBRTC TODO: Replace Record<string, never> with LineEntityItem's special properties.
 type LineEntitySubclassProperties = Record<string, never>;
@@ -29,7 +28,7 @@ type LineEntitySubclassData = {
 class LineEntityItem {
     // C++  class LineEntityItem : public EntityItem
 
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): LineEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): LineEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int LineEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/LineEntityItem.ts
+++ b/src/domain/entities/LineEntityItem.ts
@@ -12,7 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 // WEBRTC TODO: Replace Record<string, never> with LineEntityItem's special properties.
 type LineEntitySubclassProperties = Record<string, never>;
@@ -38,12 +38,12 @@ class LineEntityItem {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             // WEBRTC TODO: Read color property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LINE_POINTS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LINE_POINTS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 

--- a/src/domain/entities/MaterialEntityItem.ts
+++ b/src/domain/entities/MaterialEntityItem.ts
@@ -13,7 +13,7 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import PropertyFlags from "../shared/PropertyFlags";
 import { vec2 } from "../shared/Vec2";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 /*@sdkdoc
@@ -293,7 +293,7 @@ class MaterialEntityItem {
         const textDecoder = new TextDecoder();
 
         let materialURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -305,19 +305,19 @@ class MaterialEntityItem {
         }
 
         let materialMappingMode: MaterialMappingMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_MAPPING_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_MAPPING_MODE)) {
             materialMappingMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let priority: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_PRIORITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_PRIORITY)) {
             priority = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
         }
 
         let parentMaterialName: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PARENT_MATERIAL_NAME)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PARENT_MATERIAL_NAME)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -329,7 +329,7 @@ class MaterialEntityItem {
         }
 
         let materialMappingPos: vec2 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_MAPPING_POS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_MAPPING_POS)) {
             materialMappingPos = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN)
@@ -338,7 +338,7 @@ class MaterialEntityItem {
         }
 
         let materialMappingScale: vec2 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_MAPPING_SCALE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_MAPPING_SCALE)) {
             materialMappingScale = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN)
@@ -347,13 +347,13 @@ class MaterialEntityItem {
         }
 
         let materialMappingRot: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_MAPPING_ROT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_MAPPING_ROT)) {
             materialMappingRot = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let materialData: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_DATA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_DATA)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -365,7 +365,7 @@ class MaterialEntityItem {
         }
 
         let materialRepeat: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MATERIAL_REPEAT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MATERIAL_REPEAT)) {
             materialRepeat = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }

--- a/src/domain/entities/MaterialEntityItem.ts
+++ b/src/domain/entities/MaterialEntityItem.ts
@@ -11,9 +11,8 @@
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
-import PropertyFlags from "../shared/PropertyFlags";
 import { vec2 } from "../shared/Vec2";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 /*@sdkdoc
@@ -281,7 +280,7 @@ class MaterialEntityItem {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {MaterialEntitySubclassData} The Material entity properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): MaterialEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): MaterialEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int MaterialEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/ModelEntityItem.ts
+++ b/src/domain/entities/ModelEntityItem.ts
@@ -17,7 +17,7 @@ import PropertyFlags from "../shared/PropertyFlags";
 import type { quat } from "../shared/Quat";
 import ShapeType from "../shared/ShapeType";
 import type { vec3 } from "../shared/Vec3";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type AnimationProperties = {
@@ -154,13 +154,13 @@ class ModelEntityItem {
         const textDecoder = new TextDecoder();
 
         let shapeType: ShapeType | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SHAPE_TYPE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SHAPE_TYPE)) {
             shapeType = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let compoundShapeURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COMPOUND_SHAPE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COMPOUND_SHAPE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -174,7 +174,7 @@ class ModelEntityItem {
         }
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -184,7 +184,7 @@ class ModelEntityItem {
         }
 
         let textures: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXTURES)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXTURES)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -198,7 +198,7 @@ class ModelEntityItem {
         }
 
         let modelURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MODEL_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MODEL_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -212,7 +212,7 @@ class ModelEntityItem {
         }
 
         let modelScale: vec3 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MODEL_SCALE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MODEL_SCALE)) {
             modelScale = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -222,7 +222,7 @@ class ModelEntityItem {
         }
 
         let jointRotationsSet: boolean[] | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_JOINT_ROTATIONS_SET)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_JOINT_ROTATIONS_SET)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -243,7 +243,7 @@ class ModelEntityItem {
         }
 
         let jointRotations: quat[] | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_JOINT_ROTATIONS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_JOINT_ROTATIONS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -261,7 +261,7 @@ class ModelEntityItem {
         }
 
         let jointTranslationsSet: boolean[] | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_JOINT_TRANSLATIONS_SET)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_JOINT_TRANSLATIONS_SET)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -282,7 +282,7 @@ class ModelEntityItem {
         }
 
         let jointTranslations: vec3[] | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_JOINT_TRANSLATIONS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_JOINT_TRANSLATIONS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -303,19 +303,19 @@ class ModelEntityItem {
         }
 
         let relayParentJoints: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RELAY_PARENT_JOINTS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RELAY_PARENT_JOINTS)) {
             relayParentJoints = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let groupCulled: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GROUP_CULLED)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GROUP_CULLED)) {
             groupCulled = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let blendShapeCoefficients: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BLENDSHAPE_COEFFICIENTS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BLENDSHAPE_COEFFICIENTS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -329,13 +329,13 @@ class ModelEntityItem {
         }
 
         let useOriginalPivot: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_USE_ORIGINAL_PIVOT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_USE_ORIGINAL_PIVOT)) {
             useOriginalPivot = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let animationURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -349,49 +349,49 @@ class ModelEntityItem {
         }
 
         let animationAllowTranslation: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_ALLOW_TRANSLATION)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_ALLOW_TRANSLATION)) {
             animationAllowTranslation = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let animationFPS: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_FPS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_FPS)) {
             animationFPS = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let animationFrameIndex: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_FRAME_INDEX)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_FRAME_INDEX)) {
             animationFrameIndex = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let animationPlaying: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_PLAYING)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_PLAYING)) {
             animationPlaying = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let animationLoop: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_LOOP)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_LOOP)) {
             animationLoop = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let animationFirstFrame: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_FIRST_FRAME)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_FIRST_FRAME)) {
             animationFirstFrame = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let animationLastFrame: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_LAST_FRAME)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_LAST_FRAME)) {
             animationLastFrame = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let animationHold: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANIMATION_HOLD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANIMATION_HOLD)) {
             animationHold = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }

--- a/src/domain/entities/ModelEntityItem.ts
+++ b/src/domain/entities/ModelEntityItem.ts
@@ -13,11 +13,10 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import GLMHelpers from "../shared/GLMHelpers";
-import PropertyFlags from "../shared/PropertyFlags";
 import type { quat } from "../shared/Quat";
 import ShapeType from "../shared/ShapeType";
 import type { vec3 } from "../shared/Vec3";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type AnimationProperties = {
@@ -142,7 +141,7 @@ class ModelEntityItem {
      *  @returns {ModelEntitySubclassData} The Model entity properties and the number of bytes read.
      */
     // eslint-disable-next-line max-len
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): ModelEntitySubclassData { // eslint-disable-line class-methods-use-this
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): ModelEntitySubclassData { // eslint-disable-line class-methods-use-this
         // C++  int ModelEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/ParticleEffectEntityItem.ts
+++ b/src/domain/entities/ParticleEffectEntityItem.ts
@@ -13,11 +13,10 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import GLMHelpers from "../shared/GLMHelpers";
-import PropertyFlags from "../shared/PropertyFlags";
 import { quat } from "../shared/Quat";
 import ShapeType from "../shared/ShapeType";
 import { vec3 } from "../shared/Vec3";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -203,7 +202,7 @@ class ParticleEffectEntityItem {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {ParticleEffectEntitySubclassData} The ParticleEffect entity properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): ParticleEffectEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): ParticleEffectEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int ParticleEffectEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/ParticleEffectEntityItem.ts
+++ b/src/domain/entities/ParticleEffectEntityItem.ts
@@ -17,7 +17,7 @@ import PropertyFlags from "../shared/PropertyFlags";
 import { quat } from "../shared/Quat";
 import ShapeType from "../shared/ShapeType";
 import { vec3 } from "../shared/Vec3";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -215,13 +215,13 @@ class ParticleEffectEntityItem {
         const textDecoder = new TextDecoder();
 
         let shapeType: ShapeType | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SHAPE_TYPE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SHAPE_TYPE)) {
             shapeType = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let compoundShapeURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COMPOUND_SHAPE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COMPOUND_SHAPE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -233,7 +233,7 @@ class ParticleEffectEntityItem {
         }
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -243,7 +243,7 @@ class ParticleEffectEntityItem {
         }
 
         let alpha: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA)) {
             alpha = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
@@ -253,7 +253,7 @@ class ParticleEffectEntityItem {
         dataPosition += pulseProperties.bytesRead;
 
         let textures: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXTURES)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXTURES)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -265,49 +265,49 @@ class ParticleEffectEntityItem {
         }
 
         let maxParticles: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MAX_PARTICLES)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MAX_PARTICLES)) {
             maxParticles = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let lifespan: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LIFESPAN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LIFESPAN)) {
             lifespan = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let isEmitting: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMITTING_PARTICLES)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMITTING_PARTICLES)) {
             isEmitting = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let emitRate: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMIT_RATE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMIT_RATE)) {
             emitRate = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let emitSpeed: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMIT_SPEED)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMIT_SPEED)) {
             emitSpeed = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let speedSpread: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SPEED_SPREAD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SPEED_SPREAD)) {
             speedSpread = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let emitOrientation: quat | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMIT_ORIENTATION)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMIT_ORIENTATION)) {
             emitOrientation = GLMHelpers.unpackOrientationQuatFromBytes(data, dataPosition);
             dataPosition += 8;
         }
 
         let emitDimensions: vec3 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMIT_DIMENSIONS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMIT_DIMENSIONS)) {
             emitDimensions = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -317,37 +317,37 @@ class ParticleEffectEntityItem {
         }
 
         let emitRadiusStart: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMIT_RADIUS_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMIT_RADIUS_START)) {
             emitRadiusStart = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let polarStart: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_POLAR_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_POLAR_START)) {
             polarStart = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let polarFinish: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_POLAR_FINISH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_POLAR_FINISH)) {
             polarFinish = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let azimuthStart: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_AZIMUTH_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_AZIMUTH_START)) {
             azimuthStart = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let azimuthFinish: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_AZIMUTH_FINISH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_AZIMUTH_FINISH)) {
             azimuthFinish = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let emitAcceleration: vec3 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMIT_ACCELERATION)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMIT_ACCELERATION)) {
             emitAcceleration = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -357,7 +357,7 @@ class ParticleEffectEntityItem {
         }
 
         let accelerationSpread: vec3 | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ACCELERATION_SPREAD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ACCELERATION_SPREAD)) {
             accelerationSpread = {
                 x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -367,31 +367,31 @@ class ParticleEffectEntityItem {
         }
 
         let particleRadius: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PARTICLE_RADIUS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PARTICLE_RADIUS)) {
             particleRadius = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let radiusSpread: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RADIUS_SPREAD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RADIUS_SPREAD)) {
             radiusSpread = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let radiusStart: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RADIUS_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RADIUS_START)) {
             radiusStart = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let radiusFinish: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RADIUS_FINISH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RADIUS_FINISH)) {
             radiusFinish = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let colorSpread: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR_SPREAD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR_SPREAD)) {
             colorSpread = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -401,7 +401,7 @@ class ParticleEffectEntityItem {
         }
 
         let colorStart: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR_START)) {
             colorStart = {
                 red: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 green: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -411,7 +411,7 @@ class ParticleEffectEntityItem {
         }
 
         let colorFinish: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR_FINISH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR_FINISH)) {
             colorFinish = {
                 red: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                 green: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -421,55 +421,55 @@ class ParticleEffectEntityItem {
         }
 
         let alphaSpread: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA_SPREAD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA_SPREAD)) {
             alphaSpread = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let alphaStart: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA_START)) {
             alphaStart = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let alphaFinish: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA_FINISH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA_FINISH)) {
             alphaFinish = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let emitterShouldTrail: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EMITTER_SHOULD_TRAIL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EMITTER_SHOULD_TRAIL)) {
             emitterShouldTrail = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let particleSpin: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PARTICLE_SPIN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PARTICLE_SPIN)) {
             particleSpin = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let spinSpread: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SPIN_SPREAD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SPIN_SPREAD)) {
             spinSpread = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let spinStart: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SPIN_START)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SPIN_START)) {
             spinStart = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let spinFinish: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SPIN_FINISH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SPIN_FINISH)) {
             spinFinish = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let rotateWithEntity: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PARTICLE_ROTATE_WITH_ENTITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PARTICLE_ROTATE_WITH_ENTITY)) {
             rotateWithEntity = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }

--- a/src/domain/entities/PolyLineEntityItem.ts
+++ b/src/domain/entities/PolyLineEntityItem.ts
@@ -12,7 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with PolyLineEntityItem's special properties.
@@ -39,12 +39,12 @@ class PolyLineEntityItem {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             // WEBRTC TODO: Read color property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXTURES)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXTURES)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -54,7 +54,7 @@ class PolyLineEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LINE_POINTS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LINE_POINTS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -64,7 +64,7 @@ class PolyLineEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_STROKE_WIDTHS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_STROKE_WIDTHS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -74,7 +74,7 @@ class PolyLineEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_STROKE_NORMALS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_STROKE_NORMALS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -84,7 +84,7 @@ class PolyLineEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_STROKE_COLORS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_STROKE_COLORS)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -94,17 +94,17 @@ class PolyLineEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_IS_UV_MODE_STRETCH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_IS_UV_MODE_STRETCH)) {
             // WEBRTC TODO: Read isUVModeStretch property.
             dataPosition += 1;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LINE_GLOW)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LINE_GLOW)) {
             // WEBRTC TODO: Read lineGlow property.
             dataPosition += 1;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LINE_FACE_CAMERA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LINE_FACE_CAMERA)) {
             // WEBRTC TODO: Read lineFaceCamera property.
             dataPosition += 1;
         }

--- a/src/domain/entities/PolyLineEntityItem.ts
+++ b/src/domain/entities/PolyLineEntityItem.ts
@@ -11,8 +11,7 @@
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with PolyLineEntityItem's special properties.
@@ -30,7 +29,7 @@ type PolyLineEntitySubclassData = {
 class PolyLineEntityItem {
     // C++  class PolyLineEntityItem : public EntityItem
 
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): PolyLineEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): PolyLineEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int PolyLineEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/PolyVoxEntityItem.ts
+++ b/src/domain/entities/PolyVoxEntityItem.ts
@@ -11,8 +11,7 @@
 
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with PolyVoxEntityItem's special properties.
@@ -30,7 +29,7 @@ type PolyVoxEntitySubclassData = {
 class PolyVoxEntityItem {
     // C++  class PolyVoxEntityItem : public EntityItem
 
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): PolyVoxEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): PolyVoxEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int PolyVoxEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/PolyVoxEntityItem.ts
+++ b/src/domain/entities/PolyVoxEntityItem.ts
@@ -12,7 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with PolyVoxEntityItem's special properties.
@@ -39,12 +39,12 @@ class PolyVoxEntityItem {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_VOXEL_VOLUME_SIZE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_VOXEL_VOLUME_SIZE)) {
             // WEBRTC TODO: Read voxelVolumeSize property.
             dataPosition += 12;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_VOXEL_DATA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_VOXEL_DATA)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -56,12 +56,12 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_VOXEL_SURFACE_STYLE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_VOXEL_SURFACE_STYLE)) {
             // WEBRTC TODO: Read voxelSurfaceStyle property.
             dataPosition += 2;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_X_TEXTURE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_X_TEXTURE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -71,7 +71,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_Y_TEXTURE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_Y_TEXTURE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -81,7 +81,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_Z_TEXTURE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_Z_TEXTURE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -91,7 +91,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_X_N_NEIGHBOR_ID)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_X_N_NEIGHBOR_ID)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -101,7 +101,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_Y_N_NEIGHBOR_ID)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_Y_N_NEIGHBOR_ID)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -111,7 +111,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_Z_N_NEIGHBOR_ID)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_Z_N_NEIGHBOR_ID)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -121,7 +121,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_X_P_NEIGHBOR_ID)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_X_P_NEIGHBOR_ID)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -131,7 +131,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_Y_P_NEIGHBOR_ID)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_Y_P_NEIGHBOR_ID)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 
@@ -141,7 +141,7 @@ class PolyVoxEntityItem {
             }
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_Z_P_NEIGHBOR_ID)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_Z_P_NEIGHBOR_ID)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 

--- a/src/domain/entities/PulsePropertyGroup.ts
+++ b/src/domain/entities/PulsePropertyGroup.ts
@@ -10,7 +10,7 @@
 //
 
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with PulsePropertyGroupProperties.
@@ -34,27 +34,27 @@ class PulsePropertyGroup {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PULSE_MIN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PULSE_MIN)) {
             // WEBRTC TODO: Read pulseMin property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PULSE_MAX)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PULSE_MAX)) {
             // WEBRTC TODO: Read pulseMax property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PULSE_PERIOD)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PULSE_PERIOD)) {
             // WEBRTC TODO: Read pulsePeriod property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PULSE_COLOR_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PULSE_COLOR_MODE)) {
             // WEBRTC TODO: Read pulseColorMode property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PULSE_ALPHA_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PULSE_ALPHA_MODE)) {
             // WEBRTC TODO: Read pulseAlphaMode property.
             dataPosition += 4;
         }

--- a/src/domain/entities/PulsePropertyGroup.ts
+++ b/src/domain/entities/PulsePropertyGroup.ts
@@ -9,8 +9,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
+
+
+// NOTE: Pulse properties are deprecated and so are not implemented in the Web SDK.
 
 
 // WEBRTC TODO: Replace Record<string, never> with PulsePropertyGroupProperties.
@@ -25,7 +27,7 @@ class PulsePropertyGroup {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): PulsePropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): PulsePropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int PulsePropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/RingGizmoPropertyGroup.ts
+++ b/src/domain/entities/RingGizmoPropertyGroup.ts
@@ -9,8 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with RingGizmoPropertyGroupProperties.
@@ -25,7 +24,7 @@ class RingGizmoPropertyGroup {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): RingGizmoPropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): RingGizmoPropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int RingGizmoPropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/RingGizmoPropertyGroup.ts
+++ b/src/domain/entities/RingGizmoPropertyGroup.ts
@@ -10,7 +10,7 @@
 //
 
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 // WEBRTC TODO: Replace Record<string, never> with RingGizmoPropertyGroupProperties.
@@ -34,92 +34,92 @@ class RingGizmoPropertyGroup {
 
         let dataPosition = position;
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_START_ANGLE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_START_ANGLE)) {
             // WEBRTC TODO: Read startAngle property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_END_ANGLE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_END_ANGLE)) {
             // WEBRTC TODO: Read endAngle property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INNER_RADIUS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INNER_RADIUS)) {
             // WEBRTC TODO: Read innerRadius property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INNER_START_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INNER_START_COLOR)) {
             // WEBRTC TODO: Read innerStartColor property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INNER_END_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INNER_END_COLOR)) {
             // WEBRTC TODO: Read innerEndColor property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_OUTER_START_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_OUTER_START_COLOR)) {
             // WEBRTC TODO: Read outerStartColor property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_OUTER_END_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_OUTER_END_COLOR)) {
             // WEBRTC TODO: Read outerEndColor property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INNER_START_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INNER_START_ALPHA)) {
             // WEBRTC TODO: Read innerStartAlpha property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INNER_END_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INNER_END_ALPHA)) {
             // WEBRTC TODO: Read innerEndAlpha property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_OUTER_START_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_OUTER_START_ALPHA)) {
             // WEBRTC TODO: Read outerStartAlpha property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_OUTER_END_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_OUTER_END_ALPHA)) {
             // WEBRTC TODO: Read outerEndAlpha property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAS_TICK_MARKS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAS_TICK_MARKS)) {
             // WEBRTC TODO: Read hasTickMarks property.
             dataPosition += 1;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MAJOR_TICK_MARKS_ANGLE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MAJOR_TICK_MARKS_ANGLE)) {
             // WEBRTC TODO: Read majorTickMarksAngle property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MINOR_TICK_MARKS_ANGLE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MINOR_TICK_MARKS_ANGLE)) {
             // WEBRTC TODO: Read minorTickMarksAngle property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MAJOR_TICK_MARKS_LENGTH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MAJOR_TICK_MARKS_LENGTH)) {
             // WEBRTC TODO: Read majorTickMarksLength property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MINOR_TICK_MARKS_LENGTH)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MINOR_TICK_MARKS_LENGTH)) {
             // WEBRTC TODO: Read minorTickMarksLength property.
             dataPosition += 4;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MAJOR_TICK_MARKS_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MAJOR_TICK_MARKS_COLOR)) {
             // WEBRTC TODO: Read majorTickMarksColor property.
             dataPosition += 3;
         }
 
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MINOR_TICK_MARKS_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MINOR_TICK_MARKS_COLOR)) {
             // WEBRTC TODO: Read minorTickMarksColor property.
             dataPosition += 3;
         }

--- a/src/domain/entities/ShapeEntityItem.ts
+++ b/src/domain/entities/ShapeEntityItem.ts
@@ -13,7 +13,7 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -125,7 +125,7 @@ class ShapeEntityItem {
         let dataPosition = position;
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -135,7 +135,7 @@ class ShapeEntityItem {
         }
 
         let alpha: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA)) {
             alpha = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
@@ -147,7 +147,7 @@ class ShapeEntityItem {
         const textDecoder = new TextDecoder();
 
         let shape: Shape | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SHAPE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SHAPE)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
 

--- a/src/domain/entities/ShapeEntityItem.ts
+++ b/src/domain/entities/ShapeEntityItem.ts
@@ -12,8 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -115,7 +114,7 @@ class ShapeEntityItem {
      *  @returns {ShapeEntitySubclassData} The Shape entity properties and the number of bytes read.
      */
     // eslint-disable-next-line class-methods-use-this
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): ShapeEntitySubclassData { // eslint-disable-line max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): ShapeEntitySubclassData { // eslint-disable-line max-len
         // C++  int ShapeEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/SkyboxPropertyGroup.ts
+++ b/src/domain/entities/SkyboxPropertyGroup.ts
@@ -11,8 +11,7 @@
 
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type SkyboxProperties = {
@@ -58,7 +57,7 @@ class SkyboxPropertyGroup {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {SkyboxPropertyGroupSubclassData} The Zone entity's skybox properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): SkyboxPropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): SkyboxPropertyGroupSubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int SkyboxPropertyGroup::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/SkyboxPropertyGroup.ts
+++ b/src/domain/entities/SkyboxPropertyGroup.ts
@@ -12,7 +12,7 @@
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 
 
 type SkyboxProperties = {
@@ -70,7 +70,7 @@ class SkyboxPropertyGroup {
         const textDecoder = new TextDecoder();
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SKYBOX_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SKYBOX_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -80,7 +80,7 @@ class SkyboxPropertyGroup {
         }
 
         let url: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SKYBOX_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SKYBOX_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {

--- a/src/domain/entities/TextEntityItem.ts
+++ b/src/domain/entities/TextEntityItem.ts
@@ -13,7 +13,7 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 /*@sdkdoc
@@ -152,7 +152,7 @@ class TextEntityItem {
         dataPosition += pulseProperties.bytesRead;
 
         let text: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -164,13 +164,13 @@ class TextEntityItem {
         }
 
         let lineHeight: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LINE_HEIGHT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LINE_HEIGHT)) {
             lineHeight = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let textColor: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT_COLOR)) {
             textColor = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -180,13 +180,13 @@ class TextEntityItem {
         }
 
         let textAlpha: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT_ALPHA)) {
             textAlpha = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let backgroundColor: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BACKGROUND_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BACKGROUND_COLOR)) {
             backgroundColor = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -196,43 +196,43 @@ class TextEntityItem {
         }
 
         let backgroundAlpha: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BACKGROUND_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BACKGROUND_ALPHA)) {
             backgroundAlpha = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let leftMargin: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LEFT_MARGIN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LEFT_MARGIN)) {
             leftMargin = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let rightMargin: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RIGHT_MARGIN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RIGHT_MARGIN)) {
             rightMargin = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let topMargin: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TOP_MARGIN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TOP_MARGIN)) {
             topMargin = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let bottomMargin: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BOTTOM_MARGIN)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BOTTOM_MARGIN)) {
             bottomMargin = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let unlit: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_UNLIT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_UNLIT)) {
             unlit = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let font: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_FONT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_FONT)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -244,7 +244,7 @@ class TextEntityItem {
         }
 
         let textEffect: TextEffect | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT_EFFECT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT_EFFECT)) {
             const value = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             switch (value) {
                 case 0:
@@ -267,7 +267,7 @@ class TextEntityItem {
         }
 
         let textEffectColor: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT_EFFECT_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT_EFFECT_COLOR)) {
             textEffectColor = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -277,13 +277,13 @@ class TextEntityItem {
         }
 
         let textEffectThickness: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT_EFFECT_THICKNESS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT_EFFECT_THICKNESS)) {
             textEffectThickness = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let textAlignment: TextAlignment | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_TEXT_ALIGNMENT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_TEXT_ALIGNMENT)) {
             const value = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             switch (value) {
                 case 0:

--- a/src/domain/entities/TextEntityItem.ts
+++ b/src/domain/entities/TextEntityItem.ts
@@ -12,8 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 /*@sdkdoc
@@ -136,7 +135,7 @@ class TextEntityItem {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {TextEntitySubclassData} The Text entity properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): TextEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): TextEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int TextEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/WebEntityItem.ts
+++ b/src/domain/entities/WebEntityItem.ts
@@ -13,7 +13,7 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -122,7 +122,7 @@ class WebEntityItem {
         const textDecoder = new TextDecoder();
 
         let color: color | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLOR)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLOR)) {
             color = {
                 red: data.getUint8(dataPosition),
                 green: data.getUint8(dataPosition + 1),
@@ -132,7 +132,7 @@ class WebEntityItem {
         }
 
         let alpha: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ALPHA)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ALPHA)) {
             alpha = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
@@ -142,7 +142,7 @@ class WebEntityItem {
         dataPosition += pulseProperties.bytesRead;
 
         let sourceURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SOURCE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SOURCE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -154,13 +154,13 @@ class WebEntityItem {
         }
 
         let dpi: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_DPI)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_DPI)) {
             dpi = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
         }
 
         let scriptURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SCRIPT_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SCRIPT_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -172,31 +172,31 @@ class WebEntityItem {
         }
 
         let maxFPS: number | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MAX_FPS)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MAX_FPS)) {
             maxFPS = data.getUint8(dataPosition);
             dataPosition += 1;
         }
 
         let inputMode: WebInputMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_INPUT_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_INPUT_MODE)) {
             inputMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let showKeyboardFocusHighlight: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SHOW_KEYBOARD_FOCUS_HIGHLIGHT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SHOW_KEYBOARD_FOCUS_HIGHLIGHT)) {
             showKeyboardFocusHighlight = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let useBackground: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_WEB_USE_BACKGROUND)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_WEB_USE_BACKGROUND)) {
             useBackground = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let userAgent: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_USER_AGENT)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_USER_AGENT)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {

--- a/src/domain/entities/WebEntityItem.ts
+++ b/src/domain/entities/WebEntityItem.ts
@@ -12,8 +12,7 @@
 import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
-import PropertyFlags from "../shared/PropertyFlags";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import PulsePropertyGroup from "./PulsePropertyGroup";
 
 
@@ -110,7 +109,7 @@ class WebEntityItem {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {WebEntitySubclassData} The Web entity properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): WebEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): WebEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int WebEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/entities/ZoneEntityItem.ts
+++ b/src/domain/entities/ZoneEntityItem.ts
@@ -17,7 +17,7 @@ import PropertyFlags from "../shared/PropertyFlags";
 import ShapeType from "../shared/ShapeType";
 import AmbientLightPropertyGroup, { AmbientLightProperties } from "./AmbientLightPropertyGroup";
 import BloomPropertyGroup, { BloomProperties } from "./BloomPropertyGroup";
-import { EntityPropertyFlags } from "./EntityPropertyFlags";
+import { EntityPropertyList } from "./EntityPropertyFlags";
 import HazePropertyGroup, { HazeProperties } from "./HazePropertyGroup";
 import KeyLightPropertyGroup, { KeyLightProperties } from "./KeyLightPropertyGroup";
 import SkyboxPropertyGroup, { SkyboxProperties } from "./SkyboxPropertyGroup";
@@ -128,13 +128,13 @@ class ZoneEntityItem {
         const textDecoder = new TextDecoder();
 
         let shapeType: ShapeType | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SHAPE_TYPE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SHAPE_TYPE)) {
             shapeType = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let compoundShapeURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COMPOUND_SHAPE_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COMPOUND_SHAPE_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -162,19 +162,19 @@ class ZoneEntityItem {
         dataPosition += bloomProperties.bytesRead;
 
         let flyingAllowed: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_FLYING_ALLOWED)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_FLYING_ALLOWED)) {
             flyingAllowed = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let ghostingAllowed: boolean | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GHOSTING_ALLOWED)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GHOSTING_ALLOWED)) {
             ghostingAllowed = Boolean(data.getUint8(dataPosition));
             dataPosition += 1;
         }
 
         let filterURL: string | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_FILTER_URL)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_FILTER_URL)) {
             const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 2;
             if (length > 0) {
@@ -186,43 +186,43 @@ class ZoneEntityItem {
         }
 
         let keyLightMode: ComponentMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_KEY_LIGHT_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_KEY_LIGHT_MODE)) {
             keyLightMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let ambientLightMode: ComponentMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_AMBIENT_LIGHT_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_AMBIENT_LIGHT_MODE)) {
             ambientLightMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let skyboxMode: ComponentMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SKYBOX_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SKYBOX_MODE)) {
             skyboxMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let hazeMode: ComponentMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HAZE_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HAZE_MODE)) {
             hazeMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let bloomMode: ComponentMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BLOOM_MODE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BLOOM_MODE)) {
             bloomMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let avatarPriority: AvatarPriorityMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_AVATAR_PRIORITY)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_AVATAR_PRIORITY)) {
             avatarPriority = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }
 
         let screenshare: ComponentMode | undefined = undefined;
-        if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SCREENSHARE)) {
+        if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SCREENSHARE)) {
             screenshare = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 4;
         }

--- a/src/domain/entities/ZoneEntityItem.ts
+++ b/src/domain/entities/ZoneEntityItem.ts
@@ -13,11 +13,10 @@ import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import AvatarPriorityMode from "../shared/AvatarPriorityMode";
 import ComponentMode from "../shared/ComponentMode";
-import PropertyFlags from "../shared/PropertyFlags";
 import ShapeType from "../shared/ShapeType";
 import AmbientLightPropertyGroup, { AmbientLightProperties } from "./AmbientLightPropertyGroup";
 import BloomPropertyGroup, { BloomProperties } from "./BloomPropertyGroup";
-import { EntityPropertyList } from "./EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "./EntityPropertyFlags";
 import HazePropertyGroup, { HazeProperties } from "./HazePropertyGroup";
 import KeyLightPropertyGroup, { KeyLightProperties } from "./KeyLightPropertyGroup";
 import SkyboxPropertyGroup, { SkyboxProperties } from "./SkyboxPropertyGroup";
@@ -116,7 +115,7 @@ class ZoneEntityItem {
      *  @param {PropertyFlags} propertyFlags - The property flags.
      *  @returns {ZoneEntitySubclassData} The Zone entity properties and the number of bytes read.
      */
-    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: PropertyFlags): ZoneEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
+    static readEntitySubclassDataFromBuffer(data: DataView, position: number, propertyFlags: EntityPropertyFlags): ZoneEntitySubclassData { // eslint-disable-line class-methods-use-this, max-len
         // C++  int ZoneEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
         //      ReadBitstreamToTreeParams& args, EntityPropertyFlags& propertyFlags, bool overwriteLocalData,
         //      bool& somethingChanged)

--- a/src/domain/networking/LimitedNodeList.ts
+++ b/src/domain/networking/LimitedNodeList.ts
@@ -162,7 +162,10 @@ class LimitedNodeList {
     #_packetVersionMismatch = new SignalEmitter();
 
     #_permissions = new NodePermissions();
+    #_canRezChanged = new SignalEmitter();
+    #_canRezTmpChanged = new SignalEmitter();
     #_canKickChanged = new SignalEmitter();
+    #_canGetAndSetPrivateUserDataChanged = new SignalEmitter();
 
 
     constructor(contextID: number) {
@@ -727,6 +730,17 @@ class LimitedNodeList {
 
         // WEBRTC TODO: Address further C++ code.
 
+        if (originalPermissions.can(NodePermissions.Permission.canRezPermanentEntities)
+            !== newPermissions.can(NodePermissions.Permission.canRezPermanentEntities)) {
+            this.#_canRezChanged.emit(this.#_permissions.can(NodePermissions.Permission.canRezPermanentEntities));
+        }
+        if (originalPermissions.can(NodePermissions.Permission.canRezTemporaryEntities)
+            !== newPermissions.can(NodePermissions.Permission.canRezTemporaryEntities)) {
+            this.#_canRezTmpChanged.emit(this.#_permissions.can(NodePermissions.Permission.canRezTemporaryEntities));
+        }
+
+        // WEBRTC TODO: Address further C++ code.
+
         if (originalPermissions.can(NodePermissions.Permission.canKick)
                 !== newPermissions.can(NodePermissions.Permission.canKick)) {
             this.#_canKickChanged.emit(this.#_permissions.can(NodePermissions.Permission.canKick));
@@ -734,16 +748,56 @@ class LimitedNodeList {
 
         // WEBRTC TODO: Address further C++ code.
 
+        if (originalPermissions.can(NodePermissions.Permission.canGetAndSetPrivateUserData)
+            !== newPermissions.can(NodePermissions.Permission.canGetAndSetPrivateUserData)) {
+            this.#_canGetAndSetPrivateUserDataChanged.emit(
+                this.#_permissions.can(NodePermissions.Permission.canGetAndSetPrivateUserData)
+            );
+        }
+
+        // WEBRTC TODO: Address further C++ code.
+
     }
 
     /*@devdoc
-     *  Gets whether the node has permissions on the domain to kick (ban) users.
-     *  @returns {boolean} <code>true</code> if the node has permissions on the domain to kick (ban) users, <code>false</code>
+     *  Gets whether the node has permissions to rez (create) persistent entities in the domain.
+     *  @returns {boolean} <code>true</code> if the node has permissions to rez persistent entities in the domain,
+     *      <code>false</code> if it doesn't.
+     */
+    getThisNodeCanRez(): boolean {
+        // C++  bool getThisNodeCanRez() const
+        return this.#_permissions.can(NodePermissions.Permission.canRezPermanentEntities);
+    }
+
+    /*@devdoc
+     *  Gets whether the node has permissions to rez (create) temporary entities in the domain. Temporary entities are entities
+     *  with a finite <code>lifetime</code> property value set.
+     *  @returns {boolean} <code>true</code> if the node has permissions on the domain to rez temporary entities,
+     *      <code>false</code> if it doesn't.
+     */
+    getThisNodeCanRezTmp(): boolean {
+        // C++  bool getThisNodeCanRezTmp() const
+        return this.#_permissions.can(NodePermissions.Permission.canRezTemporaryEntities);
+    }
+
+    /*@devdoc
+     *  Gets whether the node has permissions to kick (ban) users in the domain.
+     *  @returns {boolean} <code>true</code> if the node has permissions to kick (ban) users in the domain, <code>false</code>
      *      if it doesn't.
      */
     getThisNodeCanKick(): boolean {
         // C++  bool getThisNodeCanKick() const
         return this.#_permissions.can(NodePermissions.Permission.canKick);
+    }
+
+    /*@devdoc
+     *  Gets whether the node has permissions to get and set entities' <code>privateUserData</code> properties in the domain.
+     *  @returns {boolean} <code>true</code> if the node has permissions to get and set entities' <code>privateUserData</code>
+     *      properties in the domain, <code>false</code> if it doesn't.
+     */
+    getThisNodeCanGetAndSetPrivateUserData(): boolean {
+        // C++  bool getThisNodeCanGetAndSetPrivateUserData() const
+        return this.#_permissions.can(NodePermissions.Permission.canGetAndSetPrivateUserData);
     }
 
 
@@ -817,7 +871,32 @@ class LimitedNodeList {
     }
 
     /*@devdoc
-     *  Triggered when the node's kick permissions on the domain changes.
+     *  Triggered when the node's rez persistent entities permission changes in the domain.
+     *  @function LimitedNodeList.canRezChanged
+     *  @param {boolean} canRez - <code>true</code> if the node has permission to rez persistent entities on the domain,
+     *      <code>false</code> if it doesn't.
+     *  @returns {Signal}
+     */
+    get canRezChanged(): Signal {
+        // C++  void canRezChanged(bool canRez)
+        return this.#_canRezChanged.signal();
+    }
+
+    /*@devdoc
+     *  Triggered when the node's rez temporary entities permission changes in the domain. Temporary entities are entities with
+     *  a finite <code>lifetime</code> property value set.
+     *  @function LimitedNodeList.canRezTmpChanged
+     *  @param {boolean} canRezTmp - <code>true</code> if the node has permission to rez temporary entities on the domain,
+     *      <code>false</code> if it doesn't.
+     *  @returns {Signal}
+     */
+    get canRezTmpChanged(): Signal {
+        // C++  void canRezTmpChanged(bool canRezTmp)
+        return this.#_canRezTmpChanged.signal();
+    }
+
+    /*@devdoc
+     *  Triggered when the node's kick permissions changes in the domain.
      *  @function LimitedNodeList.canKickChanged
      *  @param {boolean} canKick - <code>true</code> if the node has permissions on the domain to kick (ban) users,
      *      <code>false</code> if it doesn't.
@@ -826,6 +905,19 @@ class LimitedNodeList {
     get canKickChanged(): Signal {
         // C++  void canKickChanged(bool canKick)
         return this.#_canKickChanged.signal();
+    }
+
+    /*@devdoc
+     *  Triggered when the node's permission to get and set entities' <code>privateUserData</code> properties changes in the
+     *  domain.
+     *  @function LimitedNodeList.canGetAndSetPrivateUserDataChanged
+     *  @param {boolean} canGetAndSetPrivateUserData - <code>true</code> if the node has permission to get and set entities'
+     *      <code>privateUserData</code> properties, <code>false</code> if it doesn't.
+     *  @returns {Signal}
+     */
+    get canGetAndSetPrivateUserDataChanged(): Signal {
+        // C++  void canGetAndSetPrivateUserDataChanged(bool canGetAndSetPrivateUserData)
+        return this.#_canGetAndSetPrivateUserDataChanged.signal();
     }
 
 

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -10,7 +10,7 @@
 //
 
 import { HostType } from "../../entities/EntityItem";
-import { EntityPropertyFlags } from "../../entities/EntityPropertyFlags";
+import { EntityPropertyList } from "../../entities/EntityPropertyFlags";
 import { EntityType } from "../../entities/EntityTypes";
 import GizmoEntityItem, { GizmoEntityProperties, GizmoEntitySubclassData } from "../../entities/GizmoEntityItem";
 import GridEntityItem, { GridEntityProperties, GridEntitySubclassData } from "../../entities/GridEntityItem";
@@ -557,7 +557,7 @@ const EntityData = new class {
             dataPosition += propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
             let simOwnerData: ArrayBuffer | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SIMULATION_OWNER)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SIMULATION_OWNER)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -574,7 +574,7 @@ const EntityData = new class {
             }
 
             let parentID: Uuid | null | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PARENT_ID)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PARENT_ID)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -587,19 +587,19 @@ const EntityData = new class {
             }
 
             let parentJointIndex: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PARENT_JOINT_INDEX)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PARENT_JOINT_INDEX)) {
                 parentJointIndex = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
             }
 
             let visible: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_VISIBLE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_VISIBLE)) {
                 visible = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let name: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_NAME)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_NAME)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
                 if (length > 0) {
@@ -611,13 +611,13 @@ const EntityData = new class {
             }
 
             let locked: boolean | undefined = false;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LOCKED)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LOCKED)) {
                 locked = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let userData: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_USER_DATA)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_USER_DATA)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
                 if (length > 0) {
@@ -629,7 +629,7 @@ const EntityData = new class {
             }
 
             let privateUserData: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PRIVATE_USER_DATA)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PRIVATE_USER_DATA)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
                 if (length > 0) {
@@ -641,7 +641,7 @@ const EntityData = new class {
             }
 
             let href: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_HREF)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_HREF)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
                 if (length > 0) {
@@ -653,7 +653,7 @@ const EntityData = new class {
             }
 
             let description: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_DESCRIPTION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_DESCRIPTION)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
                 if (length > 0) {
@@ -665,7 +665,7 @@ const EntityData = new class {
             }
 
             let position: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_POSITION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_POSITION)) {
                 position = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -675,7 +675,7 @@ const EntityData = new class {
             }
 
             let dimensions: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_DIMENSIONS)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_DIMENSIONS)) {
                 dimensions = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -685,13 +685,13 @@ const EntityData = new class {
             }
 
             let rotation: quat | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ROTATION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ROTATION)) {
                 rotation = GLMHelpers.unpackOrientationQuatFromBytes(data, dataPosition);
                 dataPosition += 8;
             }
 
             let registrationPoint: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_REGISTRATION_POINT)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_REGISTRATION_POINT)) {
                 registrationPoint = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -701,13 +701,13 @@ const EntityData = new class {
             }
 
             let created: bigint | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CREATED)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CREATED)) {
                 created = data.getBigUint64(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 8;
             }
 
             let lastEditedBy: Uuid | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LAST_EDITED_BY)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)) {
                 const lastEditedLength = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -720,7 +720,7 @@ const EntityData = new class {
             const entityHostType = HostType.DOMAIN;  // Not sent over the wire.
 
             let queryAACube: AACube | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_QUERY_AA_CUBE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_QUERY_AA_CUBE)) {
                 const corner = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -735,31 +735,31 @@ const EntityData = new class {
             }
 
             let canCastShadow: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CAN_CAST_SHADOW)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CAN_CAST_SHADOW)) {
                 canCastShadow = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let renderLayer: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RENDER_LAYER)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RENDER_LAYER)) {
                 renderLayer = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let primitiveMode: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_PRIMITIVE_MODE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_PRIMITIVE_MODE)) {
                 primitiveMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let ignorePickIntersection: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_IGNORE_PICK_INTERSECTION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_IGNORE_PICK_INTERSECTION)) {
                 ignorePickIntersection = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let renderWithZones: Uuid[] | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RENDER_WITH_ZONES)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RENDER_WITH_ZONES)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -775,49 +775,49 @@ const EntityData = new class {
             }
 
             let billboardMode: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_BILLBOARD_MODE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_BILLBOARD_MODE)) {
                 billboardMode = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let grabbable: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_GRABBABLE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_GRABBABLE)) {
                 grabbable = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let grabKinematic: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_KINEMATIC)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_KINEMATIC)) {
                 grabKinematic = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let grabFollowsController: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_FOLLOWS_CONTROLLER)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_FOLLOWS_CONTROLLER)) {
                 grabFollowsController = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let triggerable: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_TRIGGERABLE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_TRIGGERABLE)) {
                 triggerable = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let grabEquippable: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_EQUIPPABLE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_EQUIPPABLE)) {
                 grabEquippable = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let delegateToParent: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_DELEGATE_TO_PARENT)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_DELEGATE_TO_PARENT)) {
                 delegateToParent = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let equippableLeftPositionOffset: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_LEFT_EQUIPPABLE_POSITION_OFFSET)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_LEFT_EQUIPPABLE_POSITION_OFFSET)) {
                 equippableLeftPositionOffset = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -827,14 +827,14 @@ const EntityData = new class {
             }
 
             let equippableLeftRotationOffset: quat | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_LEFT_EQUIPPABLE_ROTATION_OFFSET)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_LEFT_EQUIPPABLE_ROTATION_OFFSET)) {
                 equippableLeftRotationOffset
                         = GLMHelpers.unpackOrientationQuatFromBytes(data, dataPosition);
                 dataPosition += 8;
             }
 
             let equippableRightPositionOffset: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_RIGHT_EQUIPPABLE_POSITION_OFFSET)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_RIGHT_EQUIPPABLE_POSITION_OFFSET)) {
                 equippableRightPositionOffset = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -844,14 +844,14 @@ const EntityData = new class {
             }
 
             let equippableRightRotationOffset: quat | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_RIGHT_EQUIPPABLE_ROTATION_OFFSET)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_RIGHT_EQUIPPABLE_ROTATION_OFFSET)) {
                 equippableRightRotationOffset
                         = GLMHelpers.unpackOrientationQuatFromBytes(data, dataPosition);
                 dataPosition += 8;
             }
 
             let equippableIndicatorURL: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_EQUIPPABLE_INDICATOR_URL)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_EQUIPPABLE_INDICATOR_URL)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -864,7 +864,7 @@ const EntityData = new class {
             }
 
             let equippableIndicatorScale: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_EQUIPPABLE_INDICATOR_SCALE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_EQUIPPABLE_INDICATOR_SCALE)) {
                 equippableIndicatorScale = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -874,7 +874,7 @@ const EntityData = new class {
             }
 
             let equippableIndicatorOffset: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAB_EQUIPPABLE_INDICATOR_OFFSET)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAB_EQUIPPABLE_INDICATOR_OFFSET)) {
                 equippableIndicatorOffset = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -884,13 +884,13 @@ const EntityData = new class {
             }
 
             let density: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_DENSITY)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_DENSITY)) {
                 density = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let velocity: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_VELOCITY)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_VELOCITY)) {
                 velocity = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -900,7 +900,7 @@ const EntityData = new class {
             }
 
             let angularVelocity: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANGULAR_VELOCITY)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANGULAR_VELOCITY)) {
                 angularVelocity = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -910,7 +910,7 @@ const EntityData = new class {
             }
 
             let gravity: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_GRAVITY)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_GRAVITY)) {
                 gravity = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -920,7 +920,7 @@ const EntityData = new class {
             }
 
             let acceleration: vec3 | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ACCELERATION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ACCELERATION)) {
                 acceleration = {
                     x: data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN),
                     y: data.getFloat32(dataPosition + 4, UDT.LITTLE_ENDIAN),
@@ -930,55 +930,55 @@ const EntityData = new class {
             }
 
             let damping: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_DAMPING)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_DAMPING)) {
                 damping = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let angularDamping: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANGULAR_DAMPING)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ANGULAR_DAMPING)) {
                 angularDamping = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let restitution: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_RESTITUTION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_RESTITUTION)) {
                 restitution = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let friction: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_FRICTION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_FRICTION)) {
                 friction = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let lifetime: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LIFETIME)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LIFETIME)) {
                 lifetime = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let collisionless: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLLISIONLESS)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLLISIONLESS)) {
                 collisionless = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let collisionMask: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLLISION_MASK)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLLISION_MASK)) {
                 collisionMask = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
             }
 
             let dynamic: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_DYNAMIC)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_DYNAMIC)) {
                 dynamic = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let collisionSoundURL: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_COLLISION_SOUND_URL)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_COLLISION_SOUND_URL)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -991,7 +991,7 @@ const EntityData = new class {
             }
 
             let actionData: ArrayBuffer | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ACTION_DATA)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ACTION_DATA)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1007,37 +1007,37 @@ const EntityData = new class {
             }
 
             let cloneable: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CLONEABLE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CLONEABLE)) {
                 cloneable = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let cloneLifetime: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CLONE_LIFETIME)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CLONE_LIFETIME)) {
                 cloneLifetime = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let cloneLimit: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CLONE_LIMIT)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CLONE_LIMIT)) {
                 cloneLimit = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let cloneDynamic: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CLONE_DYNAMIC)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CLONE_DYNAMIC)) {
                 cloneDynamic = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let cloneAvatarIdentity: boolean | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CLONE_AVATAR_ENTITY)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CLONE_AVATAR_ENTITY)) {
                 cloneAvatarIdentity = Boolean(data.getUint8(dataPosition));
                 dataPosition += 1;
             }
 
             let cloneOriginID: Uuid | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CLONE_ORIGIN_ID)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CLONE_ORIGIN_ID)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1048,7 +1048,7 @@ const EntityData = new class {
             }
 
             let script: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SCRIPT)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SCRIPT)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1061,13 +1061,13 @@ const EntityData = new class {
             }
 
             let scriptTimestamp: bigint | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SCRIPT_TIMESTAMP)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SCRIPT_TIMESTAMP)) {
                 scriptTimestamp = data.getBigUint64(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 8;
             }
 
             let serverScripts: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_SERVER_SCRIPTS)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_SERVER_SCRIPTS)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1080,7 +1080,7 @@ const EntityData = new class {
             }
 
             let itemName: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ITEM_NAME)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ITEM_NAME)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1093,7 +1093,7 @@ const EntityData = new class {
             }
 
             let itemDescription: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ITEM_DESCRIPTION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ITEM_DESCRIPTION)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1106,7 +1106,7 @@ const EntityData = new class {
             }
 
             let itemCategories: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ITEM_CATEGORIES)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ITEM_CATEGORIES)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1119,7 +1119,7 @@ const EntityData = new class {
             }
 
             let itemArtist: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ITEM_ARTIST)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ITEM_ARTIST)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1132,7 +1132,7 @@ const EntityData = new class {
             }
 
             let itemLicense: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ITEM_LICENSE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ITEM_LICENSE)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1145,13 +1145,13 @@ const EntityData = new class {
             }
 
             let limitedRun: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_LIMITED_RUN)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_LIMITED_RUN)) {
                 limitedRun = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let marketplaceID: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_MARKETPLACE_ID)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_MARKETPLACE_ID)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1164,19 +1164,19 @@ const EntityData = new class {
             }
 
             let editionNumber: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_EDITION_NUMBER)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_EDITION_NUMBER)) {
                 editionNumber = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let entityInstanceNumber: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ENTITY_INSTANCE_NUMBER)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_ENTITY_INSTANCE_NUMBER)) {
                 entityInstanceNumber = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
             let certificateID: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CERTIFICATE_ID)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CERTIFICATE_ID)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1189,7 +1189,7 @@ const EntityData = new class {
             }
 
             let certificateType: string | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_CERTIFICATE_TYPE)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_CERTIFICATE_TYPE)) {
                 const length = data.getUint16(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 2;
 
@@ -1202,7 +1202,7 @@ const EntityData = new class {
             }
 
             let staticCertificateVersion: number | undefined = undefined;
-            if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_STATIC_CERTIFICATE_VERSION)) {
+            if (propertyFlags.getHasProperty(EntityPropertyList.PROP_STATIC_CERTIFICATE_VERSION)) {
                 staticCertificateVersion = data.getUint32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -183,7 +183,7 @@ const EntityData = new class {
      *  <p>A property value may be undefined if it couldn't fit in the data packet sent by the server.</p>
      *  @typedef {object} EntityProperties
      *
-     *  @property {Uuid} entityItemID - The ID of the entity.
+     *  @property {Uuid} entityItemID - The ID of the entity. <em>Read-only.</em>
      *  @property {EntityType} entityType - The entity's type. It cannot be changed after an entity is created.
      *  @property {bigint} createdFromBuffer - Timestamp for when the entity was created. Expressed in number of microseconds
      *      since Unix epoch.
@@ -1375,7 +1375,7 @@ const EntityData = new class {
     }
 
     // Implemented recursively in the C++ code, numberOfThreeBitSectionsInCode is here implemented iteratively.
-    #numberOfThreeBitSectionsInCode(data: DataView, dataPosition: number, maxBytes: number): number {
+    #numberOfThreeBitSectionsInCode(data: DataView, dataPosition: number, maxBytes = this.#_UNKNOWN_OCTCODE_LENGTH): number {
         // C++  int OctalCode::numberOfThreeBitSectionsInCode(const unsigned char* octalCode, int maxBytes)
 
         if (maxBytes === this.#_OVERFLOWED_OCTCODE_BUFFER) {

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -536,7 +536,7 @@ const EntityData = new class {
 
             let encodedData = new DataView(data.buffer, data.byteOffset + dataPosition);
             dataPosition += codec.decode(encodedData, encodedData.byteLength);
-            const entityType = codec.data;
+            const entityType = Number(codec.data);
 
             const createdFromBuffer = data.getBigUint64(dataPosition, UDT.LITTLE_ENDIAN);
             dataPosition += 8;
@@ -546,11 +546,11 @@ const EntityData = new class {
 
             encodedData = new DataView(data.buffer, data.byteOffset + dataPosition);
             dataPosition += codec.decode(encodedData, encodedData.byteLength);
-            const updateDelta = codec.data;
+            const updateDelta = Number(codec.data);
 
             encodedData = new DataView(data.buffer, data.byteOffset + dataPosition);
             dataPosition += codec.decode(encodedData, encodedData.byteLength);
-            const simulatedDelta = codec.data;
+            const simulatedDelta = Number(codec.data);
 
             const propertyFlags = new PropertyFlags();
             const encodedFlags = new DataView(data.buffer, data.byteOffset + dataPosition);

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -1414,7 +1414,6 @@ const EntityData = new class {
         return 1 + Math.ceil(threeBitCodes * 3 / 8.0);
     }
 
-
 }();
 
 export default EntityData;

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -10,7 +10,7 @@
 //
 
 import { HostType } from "../../entities/EntityItem";
-import { EntityPropertyList } from "../../entities/EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "../../entities/EntityPropertyFlags";
 import { EntityType } from "../../entities/EntityTypes";
 import GizmoEntityItem, { GizmoEntityProperties, GizmoEntitySubclassData } from "../../entities/GizmoEntityItem";
 import GridEntityItem, { GridEntityProperties, GridEntitySubclassData } from "../../entities/GridEntityItem";
@@ -32,7 +32,6 @@ import assert from "../../shared/assert";
 import ByteCountCoded from "../../shared/ByteCountCoded";
 import "../../shared/DataViewExtensions";
 import GLMHelpers from "../../shared/GLMHelpers";
-import PropertyFlags from "../../shared/PropertyFlags";
 import { quat } from "../../shared/Quat";
 import Uuid from "../../shared/Uuid";
 import { vec3 } from "../../shared/Vec3";
@@ -552,7 +551,7 @@ const EntityData = new class {
             dataPosition += codec.decode(encodedData, encodedData.byteLength);
             const simulatedDelta = Number(codec.data);
 
-            const propertyFlags = new PropertyFlags();
+            const propertyFlags = new EntityPropertyFlags();
             const encodedFlags = new DataView(data.buffer, data.byteOffset + dataPosition);
             dataPosition += propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import { HostType } from "../../entities/EntityItem";
 import { EntityPropertyFlags } from "../../entities/EntityPropertyFlags";
 import { EntityType } from "../../entities/EntityTypes";
 import GizmoEntityItem, { GizmoEntityProperties, GizmoEntitySubclassData } from "../../entities/GizmoEntityItem";
@@ -63,6 +64,7 @@ type CommonEntityProperties = {
     registrationPoint: vec3 | undefined;
     created: bigint | undefined;
     lastEditedBy: Uuid | undefined;
+    entityHostType: HostType | undefined;  // Not sent over the wire.
     queryAACube: AACube | undefined;
     canCastShadow: boolean | undefined;
     renderLayer: number | undefined;
@@ -217,6 +219,8 @@ const EntityData = new class {
      *      since Unix
      *  @property {Uuid|undefined} lastEditedBy - The session ID of the avatar or agent that most recently created or edited
      *      the entity.
+     *  @property {HostType|undefined} entityHostType - How the entity is hosted and sent to others for display. The value can
+     *      only be set at entity creation by {@link EntityServer#addEntity|EntityServer.addEntity}. <em>Read-only.</em>
      *  @property {AACube|undefined} queryAACube - The axis-aligned cube that determines where the entity lives in the entity
      *      server's octree. The cube may be considerably larger than the entity in some situations, e.g., when the entity is
      *      grabbed by an avatar: the position of the entity is determined through avatar mixer updates and so the AA cube is
@@ -712,6 +716,8 @@ const EntityData = new class {
                     dataPosition += 16;
                 }
             }
+
+            const entityHostType = HostType.DOMAIN;  // Not sent over the wire.
 
             let queryAACube: AACube | undefined = undefined;
             if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_QUERY_AA_CUBE)) {
@@ -1297,6 +1303,7 @@ const EntityData = new class {
                     registrationPoint,
                     created,
                     lastEditedBy,
+                    entityHostType,
                     queryAACube,
                     canCastShadow,
                     renderLayer,

--- a/src/domain/networking/packets/EntityData.ts
+++ b/src/domain/networking/packets/EntityData.ts
@@ -91,7 +91,7 @@ type CommonEntityProperties = {
     gravity: vec3 | undefined;
     acceleration: vec3 | undefined;
     damping: number | undefined;
-    angularDampling: number | undefined;
+    angularDamping: number | undefined;
     restitution: number | undefined;
     friction: number | undefined;
     lifetime: number | undefined;
@@ -278,7 +278,7 @@ const EntityData = new class {
      *      <code>0.0</code> – <code>1.0</code>. A higher damping value slows down the entity more quickly. The default value is
      *      for an exponential decay timescale of <code>2.0s</code>, where it takes <code>2.0s</code> for the movement to slow
      *      to <code>1/e = 0.368</code> of its initial value.
-     *  @property {number|undefined} angularDampling - How much the angular velocity of an entity slows down over time, range
+     *  @property {number|undefined} angularDamping - How much the angular velocity of an entity slows down over time, range
      *      <code>0.0 – 1.0</code>. A higher damping value slows down the entity more quickly. The default value is for an
      *      exponential decay timescale of <code>2.0s</code>, where it takes <code>2.0s</code> for the movement to slow to
      *      <code>1/e = 0.368</code> of its initial value.
@@ -935,9 +935,9 @@ const EntityData = new class {
                 dataPosition += 4;
             }
 
-            let angularDampling: number | undefined = undefined;
+            let angularDamping: number | undefined = undefined;
             if (propertyFlags.getHasProperty(EntityPropertyFlags.PROP_ANGULAR_DAMPING)) {
-                angularDampling = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
+                angularDamping = data.getFloat32(dataPosition, UDT.LITTLE_ENDIAN);
                 dataPosition += 4;
             }
 
@@ -1330,7 +1330,7 @@ const EntityData = new class {
                     gravity,
                     acceleration,
                     damping,
-                    angularDampling,
+                    angularDamping,
                     restitution,
                     friction,
                     lifetime,

--- a/src/domain/networking/packets/EntityEdit.ts
+++ b/src/domain/networking/packets/EntityEdit.ts
@@ -1,0 +1,104 @@
+//
+//  EntityEdit.ts
+//
+//  Created by David Rowe on 21 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import EntityItemProperties from "../../entities/EntityItemProperties";
+import EntityPropertyFlags from "../../entities/EntityPropertyFlags";
+import { AppendState } from "../../octree/OctreeElement";
+import Uuid from "../../shared/Uuid";
+import PacketTypeValue from "../udt/PacketHeaders";
+import UDT from "../udt/UDT";
+import NLPacket from "../NLPacket";
+import { EntityProperties } from "./EntityData";
+
+
+type EntityEditDetails = {
+    entityID: Uuid,
+    properties: EntityProperties,
+    requestedProperties: EntityPropertyFlags,
+    didntFitProperties: EntityPropertyFlags
+};
+
+const EntityEdit = new class {
+    // C++ N/A
+
+    /*@devdoc
+     *  Information needed for {@link PacketScribe|writing} a {@link PacketType(1)|EntityEdit} packet.
+     *  @typedef {object} PacketScribe.EntityEditDetails
+     *  @property {Uuid} entityID - The ID of the entity to edit.
+     *  @property {EntityProperties} properties - Required and changed properties for the entity edit.
+     *  @property {EntityPropertyFlags} requestedProperties - The properties requested to be included in the packet.
+     *  @property {EntityPropertyFlags} didntFitProperties - Properties that couldn't be included in the packet write because
+     *     they didn't fit. Must be empty when passed in.
+     */
+
+    /*@devdoc
+     *  Writes an {@link PacketType(1)|EntityEdit} packet, ready for sending reliably.
+     *  @function PacketScribe.EntityEdit&period;write
+     *  @param {PacketScribe.EntityEditDetails} info - The information needed for writing the packet. This information is
+     *      updated with any properties that didn't fit in the packet.
+     *  @return {NLPacket} The packet, ready for sending, or <code>null<code> if the packet couldn't be written because a
+     *      property couldn't fit.
+     */
+    write(info: EntityEditDetails): NLPacket | null {  /* eslint-disable-line class-methods-use-this */
+        // C++  OctreeElement::AppendState EntityItemProperties::encodeEntityEditPacket(PacketType command, EntityItemID id,
+        //          const EntityItemProperties& properties, QByteArray & buffer, EntityPropertyFlags requestedProperties,
+        //          EntityPropertyFlags & didntFitProperties)
+        // C++  void OctreeEditPacketSender::queueOctreeEditMessage(PacketType type, QByteArray& editMessage)
+
+        /* eslint-disable @typescript-eslint/no-magic-numbers */
+
+        const packet = NLPacket.create(PacketTypeValue.EntityEdit, -1, true);
+        const messageData = packet.getMessageData();
+        const data = messageData.data;
+        let dataPosition = messageData.dataPosition;
+
+
+        // C++  OctreeEditPacketSender::initializePacket(...)
+
+        // Leave space for the sequence number which is written when the packet is sent.
+        dataPosition += 2;
+
+        // WEBRTC TODO: Address further C++ code - clock skew.
+
+        // WEBRTC TODO: High precision timestamp.
+        const MS_TO_CLOCK_TICKS = 10000000n;
+        const now = BigInt(Date.now()) * MS_TO_CLOCK_TICKS;
+        data.setBigInt64(dataPosition, now, UDT.LITTLE_ENDIAN);
+        dataPosition += 8;
+
+
+        // C++  EntityItemProperties::encodeEntityEditPacket(...)
+
+        messageData.dataPosition = dataPosition;
+
+        info.didntFitProperties = new EntityPropertyFlags();
+
+        const appendState = EntityItemProperties.encodeEntityEditPacket(/* PacketTypeValue.EntityEdit, */ info.entityID,
+            info.properties, messageData, info.requestedProperties, info.didntFitProperties);
+        dataPosition = messageData.dataPosition;
+
+        if (appendState === AppendState.NONE) {
+            return null;
+        }
+
+
+        /* eslint-enable @typescript-eslint/no-magic-numbers */
+
+        messageData.dataPosition = dataPosition;
+        messageData.packetSize = dataPosition;
+
+        return packet;
+    }
+
+}();
+
+export default EntityEdit;
+export type { EntityEditDetails };

--- a/src/domain/networking/packets/EntityQuery.ts
+++ b/src/domain/networking/packets/EntityQuery.ts
@@ -47,7 +47,7 @@ const EntityQuery = new class {
     /*@devdoc
      *  Writes an {@link PacketType(1)|EntityQuery} packet, ready for sending.
      *  @function PacketScribe.EntityQuery&period;write
-     *  @param {PacketScribe.EntityQueryDetails} info - The information needed for writing the packet list.
+     *  @param {PacketScribe.EntityQueryDetails} info - The information needed for writing the packet.
      *  @return {NLPacket} The packet, ready for sending.
      */
     write(info: EntityQueryDetails): NLPacket {  /* eslint-disable-line class-methods-use-this */

--- a/src/domain/networking/packets/PacketScribe.ts
+++ b/src/domain/networking/packets/PacketScribe.ts
@@ -30,6 +30,7 @@ import NodeIgnoreRequest from "./NodeIgnoreRequest";
 import DomainConnectRequest from "./DomainConnectRequest";
 import EntityData from "./EntityData";
 import EntityQuery from "./EntityQuery";
+import EntityEdit from "./EntityEdit";
 import DomainServerConnectionToken from "./DomainServerConnectionToken";
 import DomainDisconnectRequest from "./DomainDisconnectRequest";
 import DomainServerRemovedNode from "./DomainServerRemovedNode";
@@ -95,6 +96,8 @@ import BulkAvatarTraitsAck from "./BulkAvatarTraitsAck";
  *      {@link PacketScribe.EntityData&period;read|EntityData&period;read}
  *  @property {function} EntityQuery.write -
  *      {@link PacketScribe.EntityQuery&period;write|EntityQuery&period;write}
+ *  @property {function} EntityEdit.write -
+ *      {@link PacketScribe.EntityEdit&period;write|EntityEdit&period;write}
  *  @property {function} DomainServerConnectionToken.read -
  *      {@link PacketScribe.DomainServerConnectionToken&period;read|DomainServerConnectionToken&period;read}
  *  @property {function} DomainDisconnectRequest.write -
@@ -156,6 +159,7 @@ const PacketScribe = {
     DomainConnectRequest,
     EntityData,
     EntityQuery,
+    EntityEdit,
     DomainServerConnectionToken,
     DomainDisconnectRequest,
     DomainServerRemovedNode,

--- a/src/domain/networking/udt/PacketHeaders.ts
+++ b/src/domain/networking/udt/PacketHeaders.ts
@@ -243,7 +243,9 @@ const enum PacketTypeValue {
  *      {@link PacketScribe.EntityQueryDetails}
  *  @property {PacketType} EntityAdd - <code>43</code>
  *  @property {PacketType} EntityErase - <code>44</code>
- *  @property {PacketType} EntityEdit - <code>45</code>
+ *  @property {PacketType} EntityEdit - <code>45</code> - The user client sends this to the Entity Server to edit an existing
+ *      entity.
+ *      {@link PacketScribe.EntityEditDetails}
  *  @property {PacketType} DomainServerConnectionToken - <code>46</code> - The Domain Server sends this to the client when the
  *      client tries to log into the domain.<br />
  *      {@link PacketScribe.DomainServerConnectionTokenDetails}

--- a/src/domain/networking/udt/PacketHeaders.ts
+++ b/src/domain/networking/udt/PacketHeaders.ts
@@ -663,6 +663,7 @@ const PacketType = new class {
                 return this.#_DomainConnectRequestVersion.SocketTypes;
             case this.AudioEnvironment:
                 return DEFAULT_VERSION;
+            case this.EntityEdit:
             case this.EntityData:
                 return this.#_EntityVersion.LAST_PACKET_TYPE;
             case this.EntityQuery:

--- a/src/domain/octree/OctreeEditPacketSender.ts
+++ b/src/domain/octree/OctreeEditPacketSender.ts
@@ -60,7 +60,7 @@ class OctreeEditPacketSender {
 
         // WEBRTC TODO: Address further C++ code - queue edits if not connected to entity server. Perhaps reuse SendQueue?
         const entityServer = this.#_nodeList.soloNodeOfType(NodeType.EntityServer);
-        if (entityServer) {
+        if (entityServer && entityServer.getActiveSocket()) {
             if (editMessage instanceof NLPacket) {
                 this.#_nodeList.sendPacket(editMessage, entityServer);
             } else {

--- a/src/domain/octree/OctreeEditPacketSender.ts
+++ b/src/domain/octree/OctreeEditPacketSender.ts
@@ -1,0 +1,75 @@
+//
+//  OctreeEditPacketSender.js
+//
+//  Created by David Rowe on 20 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import NLPacket from "../networking/NLPacket";
+import NLPacketList from "../networking/NLPacketList";
+import NodeList from "../networking/NodeList";
+import NodeType from "../networking/NodeType";
+import PacketType from "../networking/udt/PacketHeaders";
+import assert from "../shared/assert";
+import ContextManager from "../shared/ContextManager";
+
+
+/*@devdoc
+ *  The <code>OctreeEditPacketSender</code> class handles sending entity editing packets.
+ *  <p>C++: <code>class OctreeEditPacketSender : public PacketSender</code></p>
+ *
+ *  @class OctreeEditPacketSender
+ *  @param {number} contextID - The {@link ContextManager} context ID.
+ */
+class OctreeEditPacketSender {
+    // C++  class OctreeEditPacketSender : public PacketSender
+
+    static readonly contextItemType: "EntityEditPacketSender" | "OctreeEditPacketSender" = "OctreeEditPacketSender";
+
+    static #_VALID_PACKET_TYPES = [PacketType.EntityAdd, PacketType.EntityEdit, PacketType.EntityClone, PacketType.EntityErase];
+
+
+    // Context
+    #_nodeList;
+
+
+    constructor(contextID: number) {
+
+        // Context
+        this.#_nodeList = ContextManager.get(contextID, NodeList) as NodeList;
+    }
+
+
+    /*@devdoc
+     *  Sends an {@link NLPacket} or {@link NLPacketList} to the entity server.
+     *  <p>Note: The packet is sent straight away whereas the C++ queues the packet if not connected to the entity server.</p>
+     *  @param {NLPacket | NLPacketList} editMessage - The packet to send.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    queueOctreeEditMessage(/* type: PacketTypeValue, */ editMessage: NLPacket | NLPacketList): void {
+        // C++  void OctreeEditPacketSender::queueOctreeEditMessage(PacketType type, QByteArray & editMessage)
+
+        const packetType = editMessage.getType();
+        assert(OctreeEditPacketSender.#_VALID_PACKET_TYPES.indexOf(packetType) !== -1,
+            `queueOctreeEditMessage() unexpected packet type: ${packetType}`);
+
+        // WEBRTC TODO: Address further C++ code - queue edits if not connected to entity server. Perhaps reuse SendQueue?
+        const entityServer = this.#_nodeList.soloNodeOfType(NodeType.EntityServer);
+        if (entityServer) {
+            if (editMessage instanceof NLPacket) {
+                this.#_nodeList.sendPacket(editMessage, entityServer);
+            } else {
+                this.#_nodeList.sendPacketList(editMessage, entityServer);
+            }
+        } else {
+            console.warn("[EntityServer] Could not send edit message because not connected.");
+        }
+    }
+}
+
+export default OctreeEditPacketSender;

--- a/src/domain/octree/OctreeElement.ts
+++ b/src/domain/octree/OctreeElement.ts
@@ -1,0 +1,27 @@
+//
+//  OctreeElement.ts
+//
+//  Created by David Rowe on 29 Jun 20923.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+/*@devdoc
+ *  The <code>AppendState</code> namespace provides status values for appending data to a network packet.
+ *  @namespace AppendState
+ *  @property {number} COMPLETED=0 - All data were appended.
+ *  @property {number} PARTIAL=1 - Some data were appended.
+ *  @property {number} NONE=2 - No data were appended,
+ */
+enum AppendState {
+    // C++  typedef enum { COMPLETED, PARTIAL, NONE } AppendState;
+    COMPLETED,
+    PARTIAL,
+    NONE
+}
+
+export { AppendState };

--- a/src/domain/octree/OctreePacketData.ts
+++ b/src/domain/octree/OctreePacketData.ts
@@ -1,0 +1,106 @@
+//
+//  OctreePacketData.ts
+//
+//  Created by David Rowe on 17 Jul 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import EntityPropertyFlags, { EntityPropertyList } from "../entities/EntityPropertyFlags";
+import UDT from "../networking/udt/UDT";
+import { color } from "../shared/Color";
+import Uuid from "../shared/Uuid";
+import { AppendState } from "./OctreeElement";
+
+
+type OctreePacketContext = {
+    // C++  N/A
+    propertiesToWrite: EntityPropertyFlags,
+    propertiesWritten: EntityPropertyFlags,
+    propertyCount: number,
+    appendState: AppendState
+};
+
+/*@devdoc
+ *  The <code>OctreePacketData</code> namespace provides methods for writing entity properties to a packet.
+ *  <p>C++: <code>OctreePacketData</code></p>
+ *  @namespace OctreePacketData
+ */
+class OctreePacketData {
+    // C++  class OctreePacketData
+
+    /*@devdoc
+     *  The context of a packet being written.
+     *  @typedef {object} OctreePacketContext
+     *  @property {EntityPropertyFlags} propertiesToWrite - The properties remaining to be written to the packet.
+     *  @property {EntityPropertyFlags} propertiesWritten - The properties that have been written to the packet.
+     *  @property {number} propertyCount - The number of properties written to the packet.
+     *  @property {AppendState} appendState - The status of the append operation.
+     */
+
+    /*@devdoc
+     *  Appends a {@link color} value to a packet and updates the packet context.
+     *  @param {DataView} data - The packet data.
+     *  @param {number} dataPosition - The position to write the value at.
+     *  @param {color} value - The value to write.
+     *  @param {OctreePacketContext} packetContext - The context of the packet being written.
+     *  @returns {number} The number of bytes written. <code>0</code> if the value wouldn't fit.
+     */
+    static appendColorValue(data: DataView, dataPosition: number, value: color, packetContext: OctreePacketContext): number {
+        // C++  bool appendValue(const glm::u8vec3& value);
+        const NUM_BYTES = 3;
+        if (dataPosition + NUM_BYTES <= data.byteLength) {
+            data.setUint8(dataPosition, value.red);
+            data.setUint8(dataPosition + 1, value.green);
+            data.setUint8(dataPosition + 2, value.blue);
+            packetContext.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, false);
+            packetContext.propertiesWritten.setHasProperty(EntityPropertyList.PROP_COLOR, true);
+            packetContext.propertyCount += 1;
+            return NUM_BYTES;
+        }
+        packetContext.appendState = AppendState.PARTIAL;
+        return 0;
+    }
+
+    /*@devdoc
+     *  Appends a {@link Uuid} value to a packet and updates the packet context.
+     *  @param {DataView} data - The packet data.
+     *  @param {number} dataPosition - The position to write the value at.
+     *  @param {Uuid} value - The value to write.
+     *  @param {OctreePacketContext} packetContext - The context of the packet being written.
+     *  @returns {number} The number of bytes written. <code>0</code> if the value wouldn't fit.
+     */
+    static appendUUIDValue(data: DataView, dataPosition: number, value: Uuid, packetContext: OctreePacketContext): number {
+        // C++  bool OctreePacketData::appendValue(const QUuid& uuid)
+        if (value.isNull()) {
+            const NUM_BYTES = 2;
+            if (dataPosition + NUM_BYTES <= data.byteLength) {
+                data.setUint16(dataPosition, 0, UDT.LITTLE_ENDIAN);
+                packetContext.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, false);
+                packetContext.propertiesWritten.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+                packetContext.propertyCount += 1;
+                return NUM_BYTES;
+            }
+        } else {
+            const NUM_LENGTH_BYTES = 2;
+            const NUM_VALUE_BYTES = 16;
+            if (dataPosition + NUM_LENGTH_BYTES + NUM_VALUE_BYTES <= data.byteLength) {
+                data.setUint16(dataPosition, NUM_VALUE_BYTES, UDT.LITTLE_ENDIAN);
+                data.setBigUint128(dataPosition + NUM_LENGTH_BYTES, value.value(), UDT.BIG_ENDIAN);
+                packetContext.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, false);
+                packetContext.propertiesWritten.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+                packetContext.propertyCount += 1;
+                return NUM_LENGTH_BYTES + NUM_VALUE_BYTES;
+            }
+        }
+        packetContext.appendState = AppendState.PARTIAL;
+        return 0;
+    }
+
+}
+
+export default OctreePacketData;
+export type { OctreePacketContext };

--- a/src/domain/octree/OctreePacketData.ts
+++ b/src/domain/octree/OctreePacketData.ts
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import EntityPropertyFlags, { EntityPropertyList } from "../entities/EntityPropertyFlags";
+import EntityPropertyFlags from "../entities/EntityPropertyFlags";
 import UDT from "../networking/udt/UDT";
 import { color } from "../shared/Color";
 import Uuid from "../shared/Uuid";
@@ -45,19 +45,21 @@ class OctreePacketData {
      *  Appends a {@link color} value to a packet and updates the packet context.
      *  @param {DataView} data - The packet data.
      *  @param {number} dataPosition - The position to write the value at.
+     *  @param {number} flag - The property flag for the value being written.
      *  @param {color} value - The value to write.
      *  @param {OctreePacketContext} packetContext - The context of the packet being written.
      *  @returns {number} The number of bytes written. <code>0</code> if the value wouldn't fit.
      */
-    static appendColorValue(data: DataView, dataPosition: number, value: color, packetContext: OctreePacketContext): number {
+    static appendColorValue(data: DataView, dataPosition: number, flag: number, value: color,
+        packetContext: OctreePacketContext): number {
         // C++  bool appendValue(const glm::u8vec3& value);
         const NUM_BYTES = 3;
         if (dataPosition + NUM_BYTES <= data.byteLength) {
             data.setUint8(dataPosition, value.red);
             data.setUint8(dataPosition + 1, value.green);
             data.setUint8(dataPosition + 2, value.blue);
-            packetContext.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, false);
-            packetContext.propertiesWritten.setHasProperty(EntityPropertyList.PROP_COLOR, true);
+            packetContext.propertiesToWrite.setHasProperty(flag, false);
+            packetContext.propertiesWritten.setHasProperty(flag, true);
             packetContext.propertyCount += 1;
             return NUM_BYTES;
         }
@@ -69,18 +71,20 @@ class OctreePacketData {
      *  Appends a {@link Uuid} value to a packet and updates the packet context.
      *  @param {DataView} data - The packet data.
      *  @param {number} dataPosition - The position to write the value at.
+     *  @param {number} flag - The property flag for the value being written.
      *  @param {Uuid} value - The value to write.
      *  @param {OctreePacketContext} packetContext - The context of the packet being written.
      *  @returns {number} The number of bytes written. <code>0</code> if the value wouldn't fit.
      */
-    static appendUUIDValue(data: DataView, dataPosition: number, value: Uuid, packetContext: OctreePacketContext): number {
+    static appendUUIDValue(data: DataView, dataPosition: number, flag: number, value: Uuid,
+        packetContext: OctreePacketContext): number {
         // C++  bool OctreePacketData::appendValue(const QUuid& uuid)
         if (value.isNull()) {
             const NUM_BYTES = 2;
             if (dataPosition + NUM_BYTES <= data.byteLength) {
                 data.setUint16(dataPosition, 0, UDT.LITTLE_ENDIAN);
-                packetContext.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, false);
-                packetContext.propertiesWritten.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+                packetContext.propertiesToWrite.setHasProperty(flag, false);
+                packetContext.propertiesWritten.setHasProperty(flag, true);
                 packetContext.propertyCount += 1;
                 return NUM_BYTES;
             }
@@ -90,8 +94,8 @@ class OctreePacketData {
             if (dataPosition + NUM_LENGTH_BYTES + NUM_VALUE_BYTES <= data.byteLength) {
                 data.setUint16(dataPosition, NUM_VALUE_BYTES, UDT.LITTLE_ENDIAN);
                 data.setBigUint128(dataPosition + NUM_LENGTH_BYTES, value.value(), UDT.BIG_ENDIAN);
-                packetContext.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, false);
-                packetContext.propertiesWritten.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+                packetContext.propertiesToWrite.setHasProperty(flag, false);
+                packetContext.propertiesWritten.setHasProperty(flag, true);
                 packetContext.propertyCount += 1;
                 return NUM_LENGTH_BYTES + NUM_VALUE_BYTES;
             }

--- a/src/domain/octree/OctreePacketData.ts
+++ b/src/domain/octree/OctreePacketData.ts
@@ -53,6 +53,12 @@ class OctreePacketData {
     static appendColorValue(data: DataView, dataPosition: number, flag: number, value: color,
         packetContext: OctreePacketContext): number {
         // C++  bool appendValue(const glm::u8vec3& value);
+        const valid = typeof value.red === "number" && typeof value.green === "number" && typeof value.blue === "number";
+        if (!valid) {
+            console.error("[EntityServer] Cannot write invalid color value to packet!");
+            return 0;
+        }
+
         const NUM_BYTES = 3;
         if (dataPosition + NUM_BYTES <= data.byteLength) {
             data.setUint8(dataPosition, value.red);
@@ -79,6 +85,12 @@ class OctreePacketData {
     static appendUUIDValue(data: DataView, dataPosition: number, flag: number, value: Uuid,
         packetContext: OctreePacketContext): number {
         // C++  bool OctreePacketData::appendValue(const QUuid& uuid)
+        const valid = value instanceof Uuid;
+        if (!valid) {
+            console.error("[EntityServer] Cannot write invalid UUID value to packet!");
+            return 0;
+        }
+
         if (value.isNull()) {
             const NUM_BYTES = 2;
             if (dataPosition + NUM_BYTES <= data.byteLength) {

--- a/src/domain/shared/ByteCountCoded.ts
+++ b/src/domain/shared/ByteCountCoded.ts
@@ -16,7 +16,7 @@
  *  <p>C++: <code>template&lt;typename T&gt; class ByteCountCoded</code></p>
  *  @class ByteCountCoded
  *
- *  @property {number} data - The integer value to encode or the decoded integer value.
+ *  @property {bigint} data - The integer value to encode or the decoded integer value.
  */
 // WEBRTC TODO: Make the class generic.
 class ByteCountCoded {
@@ -135,26 +135,26 @@ class ByteCountCoded {
         let valueBits = totalBits;
         let firstValueFound = false;
         let temp = this.#_data;
-        let lastBitMask = 1n << BigInt(totalBits - 1);
+        const lastBitMask = 1n << BigInt(totalBits - 1);
 
         // determine the number of bits that the value takes
         for (let bitAt = 0; bitAt < totalBits; bitAt++) {
-            let bitValue = (temp & lastBitMask) === lastBitMask;
+            const bitValue = (temp & lastBitMask) === lastBitMask;
             if (!firstValueFound) {
                 if (!bitValue) {
-                    valueBits--;
+                    valueBits -= 1;
                 } else {
                     firstValueFound = true;
                 }
             }
             temp = temp << 1n;
         }
-    
+
         // Calculate the number of total bytes, including our header.
         // BITS_IN_BYTE-1 because we need to code the number of bytes in the header
         // + 1 because we always take at least 1 byte, even if number of bits is less than a bytes worth
         const BITS_IN_BYTE = 8;
-        let numberOfBytes = Math.trunc(valueBits / (BITS_IN_BYTE - 1)) + 1; 
+        const numberOfBytes = Math.trunc(valueBits / (BITS_IN_BYTE - 1)) + 1; 
 
         // Fill data with initial 0s.
         for (let i = 0; i < numberOfBytes; i++) {
@@ -162,23 +162,23 @@ class ByteCountCoded {
         }
 
         // Next, pack the number of header bits in, the first N-1 to be set to 1, the last to be set to 0.
-        for(let i = 0; i < numberOfBytes; i++) {
-            let outputIndex = i;
-            let bitValue = (i < (numberOfBytes - 1)  ? 1 : 0);
-            let original = data.getUint8(outputIndex / BITS_IN_BYTE);
-            let shiftBy = BITS_IN_BYTE - ((outputIndex % BITS_IN_BYTE) + 1);
-            let thisBit = bitValue << shiftBy;
+        for (let i = 0; i < numberOfBytes; i++) {
+            const outputIndex = i;
+            const bitValue = i < numberOfBytes - 1 ? 1 : 0;
+            const original = data.getUint8(outputIndex / BITS_IN_BYTE);
+            const shiftBy = BITS_IN_BYTE - (outputIndex % BITS_IN_BYTE + 1);
+            const thisBit = bitValue << shiftBy;
             data.setUint8(i / BITS_IN_BYTE, original | thisBit);
         }
 
         // finally pack the actual bits from the bit array.
         temp = this.#_data;
-        for(let i = numberOfBytes; i < (numberOfBytes + valueBits); i++) {
-            let outputIndex = i;
-            let bitValue = temp & 1n;
-            let original = data.getUint8(outputIndex / BITS_IN_BYTE);
-            let shiftBy = Math.trunc(BITS_IN_BYTE - ((outputIndex % BITS_IN_BYTE) + 1));
-            let thisBit = bitValue << BigInt(shiftBy);
+        for (let i = numberOfBytes; i < numberOfBytes + valueBits; i++) {
+            const outputIndex = i;
+            const bitValue = temp & 1n;
+            const original = data.getUint8(outputIndex / BITS_IN_BYTE);
+            const shiftBy = Math.trunc(BITS_IN_BYTE - (outputIndex % BITS_IN_BYTE + 1));
+            const thisBit = bitValue << BigInt(shiftBy);
             data.setUint8(i / BITS_IN_BYTE, original | Number(thisBit));
             temp = temp >> 1n;
         }

--- a/src/domain/shared/DataViewExtensions.ts
+++ b/src/domain/shared/DataViewExtensions.ts
@@ -12,7 +12,7 @@
 /*@devdoc
  *  The <code>DataView</code> namespace comprises methods added to the prototype of JavaScript's
  *  {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView|DataView} object, for
- *  handling reading and writing large <code>bigint</vcde> values. These methods are added only if they aren't already present
+ *  handling reading and writing large <code>bigint</code> values. These methods are added only if they aren't already present
  *  in the browser's <code>DataView</code> implementation.
  *  <p>C++: N/A</p>
  *  @namespace DataView

--- a/src/domain/shared/JSONExtensions.ts
+++ b/src/domain/shared/JSONExtensions.ts
@@ -53,8 +53,7 @@ export function bigintReplacer(key: string, value: unknown): unknown {
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export function bigintReviver(key: string, value: unknown): unknown {
-    if (typeof value === "string" && value.endsWith("n")) {  // $$$$$$: Match
-        console.debug("$$$$... return", BigInt(value.slice(0, -1)));
+    if (typeof value === "string" && value.endsWith("n")) {
         return BigInt(value.slice(0, -1));
     }
     return value;

--- a/src/domain/shared/JSONExtensions.ts
+++ b/src/domain/shared/JSONExtensions.ts
@@ -1,0 +1,55 @@
+//
+//  JSONExtensions.ts
+//
+//  Created by David Rowe on 3 Jul 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/*@devdoc
+ *  The <code>JSONExtensions</code> namespace provides "replacer" and "reviver" methods for use when stringifying and parsing
+    JSON with <code>bigint</code> values.
+ *  <p>C++: N/A</p>
+ *  @namespace JSONExtensions
+ */
+
+/*@devdoc
+ *  Replaces a <code>bigint</code> value in a JSON object being stringified. Use as the second parameter in the
+ *  {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify|JSON.stringify()}
+ *  call.
+ *  @function JSONExtensions.bigintReplacer
+ *  @param {string} key - The key of the property being processed.
+ *  @param {unknown} value - The value of the property being processed.
+ *  @returns {string|unknown} A numeric string ending with <code>"n"</code> if the value is a <code>bigint</code>, otherwise the
+ *      unaltered <code>value</code> passed in.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export function bigintReplacer(key: string, value: unknown): unknown {
+    if (typeof value === "bigint") {
+        return value.toString() + "n";
+    }
+    return value;
+}
+
+/*@devdoc
+ *  Revives a <code>bigint</code> value in a stringified JSON object. Use as the second parameter in the
+ *  {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse|JSON.parse()} call.
+ *  @function JSONExtensions.bigintReviver
+ *  @param {string} key - The key of the property being processed.
+ *  @param {unknown} value - The stringified value of the property being processed.
+ *  @returns {bigint|unknown} The <code>bigint</code> value of the <code>value</code> if it's a numeric string ending with
+ *      <code>"n"</code>, otherwise the unaltered <code>value</code> passed in.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export function bigintReviver(key: string, value: unknown): unknown {
+    if (typeof value === "string" && value.endsWith("n")) {  // $$$$$$: Match
+        console.debug("$$$$... return", BigInt(value.slice(0, -1)));
+        return BigInt(value.slice(0, -1));
+    }
+    return value;
+}

--- a/src/domain/shared/JSONExtensions.ts
+++ b/src/domain/shared/JSONExtensions.ts
@@ -9,6 +9,9 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import Uuid from "./Uuid";
+
+
 /*@devdoc
  *  The <code>JSONExtensions</code> namespace provides "replacer" and "reviver" methods for use when stringifying and parsing
     JSON with <code>bigint</code> values.
@@ -23,14 +26,17 @@
  *  @function JSONExtensions.bigintReplacer
  *  @param {string} key - The key of the property being processed.
  *  @param {unknown} value - The value of the property being processed.
- *  @returns {string|unknown} A numeric string ending with <code>"n"</code> if the value is a <code>bigint</code>, otherwise the
- *      unaltered <code>value</code> passed in.
+ *  @returns {string|unknown} A numeric string ending with <code>"n"</code> if the value is a <code>bigint</code> or
+ *      {@link Uuid}, otherwise the unaltered <code>value</code> passed in.
  */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export function bigintReplacer(key: string, value: unknown): unknown {
     if (typeof value === "bigint") {
         return value.toString() + "n";
+    }
+    if (value instanceof Uuid) {
+        return value.value().toString() + "n";
     }
     return value;
 }

--- a/src/domain/shared/PropertyFlags.ts
+++ b/src/domain/shared/PropertyFlags.ts
@@ -36,13 +36,24 @@ class PropertyFlags {
 
 
     /*@devdoc
+     *  Copies the flags from another instance.
+     *  @param {PropertyFlags} other - The other instance to copy the flags from.
+     */
+    copy(other: PropertyFlags): void {
+        // C++  operator = (const PropertyFlags& other)
+        this.#clear();
+        for (let i = 0, length = other.length(); i < length; i++) {
+            this.setHasProperty(i, other.getHasProperty(i));
+        }
+    }
+
+    /*@devdoc
      *  Gets whether the property flags are empty.
      *  @returns {boolean} <code>true</code> if no property flags are set, <code>false</code> if one or more are set.
      */
     isEmpty(): boolean {
         // C++  bool isEmpty()
-        return this.#_maxFlag === Number.MIN_SAFE_INTEGER && this.#_minFlag === Number.MAX_SAFE_INTEGER
-            && this.#_trailingFlipped === false && this.#_encodedLength === 0;
+        return this.#_trailingFlipped === false && this.#_encodedLength === 0;
     }
 
     /*@devdoc
@@ -218,17 +229,20 @@ class PropertyFlags {
 
     /*@devdoc
      *  Outputs debug information about the property flags to the console.
+     *  @param {string} [prefix] - A string to prefix the debug output with.
      */
-    debugDumpBits(): void {
+    debugDumpBits(prefix?: string): void {
         // C++  void PropertyFlags<Enum>::debugDumpBits()
-        //console.debug("#_minFlag=", this.#_minFlag);
-        //console.debug("#_maxFlag=", this.#_maxFlag);
-        //console.debug("#_trailingFlipped=", this.#_trailingFlipped);
+        // console.debug("#_minFlag =", this.#_minFlag);
+        // console.debug("#_maxFlag =", this.#_maxFlag);
+        // console.debug("#_trailingFlipped =", this.#_trailingFlipped);
+        // console.debug("#_encodedLength =", this.#_encodedLength);
+        // console.debug("#_flags.length =", this.#_flags.length);
         let bits = "";
         for (let i = 0; i < this.#_flags.length; i++) {
             bits += this.#_flags[i] ? "1" : "0";
         }
-        console.debug("bits:", bits);
+        console.debug(`${prefix ? prefix + " " : ""}bits:`, bits);
     }
 
     #clear(): void {

--- a/src/domain/shared/PropertyFlags.ts
+++ b/src/domain/shared/PropertyFlags.ts
@@ -26,6 +26,17 @@ class PropertyFlags {
     #_maxFlag = Number.MIN_SAFE_INTEGER;
     #_minFlag = Number.MAX_SAFE_INTEGER;
     #_trailingFlipped = false;
+    #_encodedLength = 0;
+
+    /*@devdoc
+     *  Gets whether the property flags are empty.
+     *  @returns {boolean} <code>true</code> if no property flags are set, <code>false</code> if one or more are set.
+     */
+    isEmpty(): boolean {
+        // C++  bool isEmpty()
+        return this.#_maxFlag === Number.MIN_SAFE_INTEGER && this.#_minFlag === Number.MAX_SAFE_INTEGER
+            && this.#_trailingFlipped === false && this.#_encodedLength === 0;
+    }
 
     /*@devdoc
      *  Gets whether the property flag is present in the flags sent by the server.
@@ -33,7 +44,7 @@ class PropertyFlags {
      *  @returns {boolean} <code>true</code> if the property flag is present, <code>false</code> if it isn't.
      */
     getHasProperty(flag: number): boolean {
-        // C++ bool getHasProperty(Enum flag)
+        // C++  bool getHasProperty(Enum flag)
 
         const bytePos = Math.floor(flag / this.#BITS_IN_BYTE);
 
@@ -55,7 +66,7 @@ class PropertyFlags {
      *  @param {boolean} value - The value to set the flag to.
      */
     setHasProperty(flag: number, value: boolean): void {
-        // C++ void setHasProperty(Enum flag, bool value = true)
+        // C++  void setHasProperty(Enum flag, bool value = true)
 
         const bytePos = Math.floor(flag / this.#BITS_IN_BYTE);
 
@@ -100,7 +111,7 @@ class PropertyFlags {
      *  @returns {number} The number of bytes processed.
      */
     decode(data: DataView, size: number): number {
-        // C++ size_t decode(const uint8_t* data, size_t length)
+        // C++  size_t decode(const uint8_t* data, size_t length)
 
         /* Process each bit of each  byte until the stop condition is reached.
         * Starts from the leftmost bit.
@@ -168,19 +179,17 @@ class PropertyFlags {
             }
         }
 
-        // WEBRTC TODO: Address further C++ code.
-
+        this.#_encodedLength = bytesConsumed;
         return bytesConsumed;
     }
 
     #clear(): void {
-        // C++ void clear()
+        // C++  void clear()
         this.#_flags = new Uint8Array(0);
         this.#_maxFlag = Number.MIN_SAFE_INTEGER;
         this.#_minFlag = Number.MAX_SAFE_INTEGER;
         this.#_trailingFlipped = false;
-
-        // WEBRTC TODO: Address further C++ code.
+        this.#_encodedLength = 0;
     }
 }
 

--- a/src/domain/shared/PropertyFlags.ts
+++ b/src/domain/shared/PropertyFlags.ts
@@ -221,9 +221,9 @@ class PropertyFlags {
      */
     debugDumpBits(): void {
         // C++  void PropertyFlags<Enum>::debugDumpBits()
-        console.debug("#_minFlag=", this.#_minFlag);
-        console.debug("#_maxFlag=", this.#_maxFlag);
-        console.debug("#_trailingFlipped=", this.#_trailingFlipped);
+        //console.debug("#_minFlag=", this.#_minFlag);
+        //console.debug("#_maxFlag=", this.#_maxFlag);
+        //console.debug("#_trailingFlipped=", this.#_trailingFlipped);
         let bits = "";
         for (let i = 0; i < this.#_flags.length; i++) {
             bits += this.#_flags[i] ? "1" : "0";

--- a/tests/EntityServer.unit.test.js
+++ b/tests/EntityServer.unit.test.js
@@ -83,7 +83,7 @@ describe("EntityServer - unit tests", () => {
         expect(uuid.isNull()).toBe(true);
         expect(errorMessage).toBe("[EntityServer] addEntity() for local entities not implemented!");
 
-        // Successful call in contrast.
+        // Successful call.
         errorMessage = "";
         uuid = entityServer.addEntity({ entityType: EntityType.Shape }, HostType.DOMAIN);
         expect(uuid.isNull()).toBe(false);

--- a/tests/EntityServer.unit.test.js
+++ b/tests/EntityServer.unit.test.js
@@ -30,4 +30,21 @@ describe("EntityServer - unit tests", () => {
         expect(entityServer instanceof EntityServer).toBe(true);
     });
 
+    test("Can get user permissions", () => {
+
+        const domainServer = new DomainServer();
+        const camera = new Camera(domainServer.contextID);  // eslint-disable-line @typescript-eslint/no-unused-vars
+        const entityServer = new EntityServer(domainServer.contextID);
+
+        expect(typeof entityServer.canRez).toBe("boolean");
+        expect(typeof entityServer.canRezChanged.connect).toBe("function");
+        expect(typeof entityServer.canRezChanged.disconnect).toBe("function");
+        expect(typeof entityServer.canRezTemp).toBe("boolean");
+        expect(typeof entityServer.canRezTempChanged.connect).toBe("function");
+        expect(typeof entityServer.canRezTempChanged.disconnect).toBe("function");
+        expect(typeof entityServer.canGetAndSetPrivateUserData).toBe("boolean");
+        expect(typeof entityServer.canGetAndSetPrivateUserDataChanged.connect).toBe("function");
+        expect(typeof entityServer.canGetAndSetPrivateUserDataChanged.disconnect).toBe("function");
+    });
+
 });

--- a/tests/EntityServer.unit.test.js
+++ b/tests/EntityServer.unit.test.js
@@ -152,6 +152,9 @@ describe("EntityServer - unit tests", () => {
         expect(errorMessage).toBe("");
         expect(uuid.isNull()).toBe(true);
 
+        // Invalid property values.
+        // Tested in EntityEditPacketSender.unit.test.js.
+
         warn.mockRestore();
         error.mockRestore();
     });

--- a/tests/EntityServer.unit.test.js
+++ b/tests/EntityServer.unit.test.js
@@ -78,7 +78,10 @@ describe("EntityServer - unit tests", () => {
         // Unsupported host type.
         uuid = entityServer.addEntity({ entityType: EntityType.Shape }, EntityHostType.AVATAR);
         expect(uuid.isNull()).toBe(true);
-        expect(errorMessage).toBe("[EntityServer] addEntity() called with unsupported entity hostType!");
+        expect(errorMessage).toBe("[EntityServer] addEntity() for avatar entities not implemented!");
+        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, EntityHostType.LOCAL);
+        expect(uuid.isNull()).toBe(true);
+        expect(errorMessage).toBe("[EntityServer] addEntity() for local entities not implemented!");
 
         // Successful call in contrast.
         errorMessage = "";

--- a/tests/EntityServer.unit.test.js
+++ b/tests/EntityServer.unit.test.js
@@ -15,7 +15,7 @@ AccountManagerMock.mock();
 import { webcrypto } from "crypto";
 globalThis.crypto = webcrypto;
 
-import { EntityHostType } from "../src/domain/entities/EntityHostType";
+import { HostType } from "../src/domain/entities/EntityItem";
 import { EntityType } from "../src/domain/entities/EntityTypes";
 import Camera from "../src/Camera";
 import DomainServer from "../src/DomainServer";
@@ -76,16 +76,16 @@ describe("EntityServer - unit tests", () => {
         expect(errorMessage).toBe("[EntityServer] addEntity() called with invalid entity hostType!");
 
         // Unsupported host type.
-        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, EntityHostType.AVATAR);
+        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, HostType.AVATAR);
         expect(uuid.isNull()).toBe(true);
         expect(errorMessage).toBe("[EntityServer] addEntity() for avatar entities not implemented!");
-        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, EntityHostType.LOCAL);
+        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, HostType.LOCAL);
         expect(uuid.isNull()).toBe(true);
         expect(errorMessage).toBe("[EntityServer] addEntity() for local entities not implemented!");
 
         // Successful call in contrast.
         errorMessage = "";
-        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, EntityHostType.DOMAIN);
+        uuid = entityServer.addEntity({ entityType: EntityType.Shape }, HostType.DOMAIN);
         expect(uuid.isNull()).toBe(false);
         expect(errorMessage).toBe("");
 

--- a/tests/domain/entities/EntityEditPacketSender.unit.test.js
+++ b/tests/domain/entities/EntityEditPacketSender.unit.test.js
@@ -134,4 +134,32 @@ describe("EntityEditPacketSender - unit tests", () => {
         });
     });
 
+    test("Error is logged when entity property value is invalid", () => {
+        let errorMessage = "";
+        const error = jest.spyOn(console, "error").mockImplementation((...message) => {
+            errorMessage = message.join(" ");
+        });
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => { /* no-op */ });
+
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, EntityEditPacketSender, contextID);
+        const entityEditPacketSender = ContextManager.get(contextID, EntityEditPacketSender);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        entityEditPacketSender.queueEditEntityMessage(PacketType.EntityEdit, Uuid.createUuid(), {
+            entityType: EntityType.Box,
+            lastEdited: 0n,
+            parentID: new Uuid(Uuid.AVATAR_SELF_ID),
+            color: { red: 255, green: 255, blue: "" }
+        });
+
+        expect(errorMessage).toBe("[EntityServer] Cannot write invalid color value to packet!");
+
+        error.mockRestore();
+        warn.mockRestore();
+    });
+
 });

--- a/tests/domain/entities/EntityEditPacketSender.unit.test.js
+++ b/tests/domain/entities/EntityEditPacketSender.unit.test.js
@@ -1,0 +1,137 @@
+//
+//  EntityEditPacketSender.unit.test.js
+//
+//  Created by David Rowe on 19 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { webcrypto } from "crypto";
+globalThis.crypto = webcrypto;
+
+import EntityEditPacketSender from "../../../src/domain/entities/EntityEditPacketSender";
+import { EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+import { EntityType } from "../../../src/domain/entities/EntityTypes";
+import PacketScribe from "../../../src/domain/networking/packets/PacketScribe";
+import PacketType from "../../../src/domain/networking/udt/PacketHeaders";
+import AccountManager from "../../../src/domain/networking/AccountManager";
+import AddressManager from "../../../src/domain/networking/AddressManager";
+import NodeList from "../../../src/domain/networking/NodeList";
+import NodePermissions from "../../../src/domain/networking/NodePermissions";
+import ContextManager from "../../../src/domain/shared/ContextManager";
+import Uuid from "../../../src/domain/shared/Uuid";
+
+
+describe("EntityEditPacketSender - unit tests", () => {
+
+    test("An EntityEditPacketSender can be obtained from the ContextManager", () => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, EntityEditPacketSender, contextID);
+        const entityEditPacketSender = ContextManager.get(contextID, EntityEditPacketSender);
+        expect(entityEditPacketSender instanceof EntityEditPacketSender).toBe(true);
+    });
+
+    test("AVATAR_SELF_ID parentID property value is replaced with the user's session UUID", (done) => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, EntityEditPacketSender, contextID);
+        const entityEditPacketSender = ContextManager.get(contextID, EntityEditPacketSender);
+
+        const log = jest.spyOn(console, "log").mockImplementation((...message) => {
+            const messageString = message.join(" ");
+            const EXPECTED_MESSAGE_SLICE = "[networking] NodeList UUID changed from 00000000-0000-0000-0000-000000000000";
+            expect(messageString.slice(0, EXPECTED_MESSAGE_SLICE.length)).toBe(EXPECTED_MESSAGE_SLICE);
+        });
+
+        const sessionUUID = Uuid.createUuid();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        ContextManager.get(contextID, NodeList).setSessionUUID(sessionUUID);
+
+        log.mockRestore();
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        const originalWrite = PacketScribe.EntityEdit.write;
+        const queueOctreeEditPacket = jest.spyOn(entityEditPacketSender, "queueOctreeEditMessage").mockImplementation(() => {
+            queueOctreeEditPacket.mockRestore();
+            PacketScribe.EntityEdit.write = originalWrite;
+            done();
+        });
+        PacketScribe.EntityEdit.write = jest.fn((info) => {
+            expect(info.properties.parentID).toBe(sessionUUID);
+            return originalWrite(info);
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        entityEditPacketSender.queueEditEntityMessage(PacketType.EntityEdit, Uuid.createUuid(), {
+            entityType: EntityType.Box,
+            lastEdited: 0n,
+            parentID: new Uuid(Uuid.AVATAR_SELF_ID)
+        });
+    });
+
+    test("Private user data property is removed if user doesn't have necessary permissions", (done) => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, EntityEditPacketSender, contextID);
+        const entityEditPacketSender = ContextManager.get(contextID, EntityEditPacketSender);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const newPermissions = new NodePermissions();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        ContextManager.get(contextID, NodeList).setPermissions(newPermissions);
+
+        expect.assertions(2);
+
+        let testWithPermissions = false;
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        const originalWrite = PacketScribe.EntityEdit.write;
+        const queueOctreeEditPacket = jest.spyOn(entityEditPacketSender, "queueOctreeEditMessage").mockImplementation(() => {
+            if (testWithPermissions) {
+                queueOctreeEditPacket.mockRestore();
+                PacketScribe.EntityEdit.write = originalWrite;
+                done();
+            }
+        });
+        PacketScribe.EntityEdit.write = jest.fn((info) => {
+            expect(info.requestedProperties.getHasProperty(EntityPropertyList.PROP_PRIVATE_USER_DATA))
+                .toBe(testWithPermissions);
+            return originalWrite(info);
+        });
+
+        testWithPermissions = false;
+        newPermissions.permissions = NodePermissions.Permission.canAdjustLocks;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        ContextManager.get(contextID, NodeList).setPermissions(newPermissions);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        entityEditPacketSender.queueEditEntityMessage(PacketType.EntityEdit, Uuid.createUuid(), {
+            entityType: EntityType.Box,
+            lastEdited: 0n,
+            privateUserData: "private user data",
+            color: { red: 0, green: 0, blue: 0 }
+        });
+
+        testWithPermissions = true;
+        newPermissions.permissions = NodePermissions.Permission.canGetAndSetPrivateUserData;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        ContextManager.get(contextID, NodeList).setPermissions(newPermissions);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        entityEditPacketSender.queueEditEntityMessage(PacketType.EntityEdit, Uuid.createUuid(), {
+            entityType: EntityType.Box,
+            lastEdited: 0n,
+            privateUserData: "private user data",
+            color: { red: 0, green: 0, blue: 0 }
+        });
+    });
+
+});

--- a/tests/domain/entities/EntityHostType.unit.test.js
+++ b/tests/domain/entities/EntityHostType.unit.test.js
@@ -1,0 +1,22 @@
+//
+//  EntityHostType.unit.test.js
+//
+//  Created by David Rowe on 19 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { EntityHostType } from "../../../src/domain/entities/EntityHostType";
+
+describe("EntityHostType - unit tests", () => {
+
+    test("Can get entity host types", () => {
+        expect(EntityHostType.DOMAIN).toBe(0);
+        expect(EntityHostType.LOCAL).toBe(1);
+        expect(EntityHostType.AVATAR).toBe(2);
+    });
+
+});

--- a/tests/domain/entities/EntityHostType.unit.test.js
+++ b/tests/domain/entities/EntityHostType.unit.test.js
@@ -15,8 +15,8 @@ describe("EntityHostType - unit tests", () => {
 
     test("Can get entity host types", () => {
         expect(EntityHostType.DOMAIN).toBe(0);
-        expect(EntityHostType.LOCAL).toBe(1);
-        expect(EntityHostType.AVATAR).toBe(2);
+        expect(EntityHostType.AVATAR).toBe(1);
+        expect(EntityHostType.LOCAL).toBe(2);
     });
 
 });

--- a/tests/domain/entities/EntityItem.unit.test.js
+++ b/tests/domain/entities/EntityItem.unit.test.js
@@ -1,5 +1,5 @@
 //
-//  EntityHostType.unit.test.js
+//  EntityItem.unit.test.js
 //
 //  Created by David Rowe on 19 Jun 2023.
 //  Copyright 2023 Vircadia contributors.
@@ -9,14 +9,14 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import { EntityHostType } from "../../../src/domain/entities/EntityHostType";
+import { HostType } from "../../../src/domain/entities/EntityItem";
 
-describe("EntityHostType - unit tests", () => {
+describe("EntityItem - unit tests", () => {
 
     test("Can get entity host types", () => {
-        expect(EntityHostType.DOMAIN).toBe(0);
-        expect(EntityHostType.AVATAR).toBe(1);
-        expect(EntityHostType.LOCAL).toBe(2);
+        expect(HostType.DOMAIN).toBe(0);
+        expect(HostType.AVATAR).toBe(1);
+        expect(HostType.LOCAL).toBe(2);
     });
 
 });

--- a/tests/domain/entities/EntityItemProperties.unit.test.js
+++ b/tests/domain/entities/EntityItemProperties.unit.test.js
@@ -10,10 +10,18 @@
 //
 
 import EntityItemProperties from "../../../src/domain/entities/EntityItemProperties";
-import { EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+import { EntityType } from "../../../src/domain/entities/EntityTypes";
+import UDT from "../../../src/domain/networking/udt/UDT";
+import MessageData from "../../../src/domain/networking/MessageData";
+import { AppendState } from "../../../src/domain/octree/OctreeElement";
+import Uuid from "../../../src/domain/shared/Uuid";
+
+import { buffer2hex } from "../../testUtils";
 
 
 describe("EntityItemsProperties - unit test", () => {
+    /* eslint-disable @typescript-eslint/no-magic-numbers */
 
     test("No changed properties are calculated for empty properties value", () => {
         const properties = {};
@@ -34,6 +42,100 @@ describe("EntityItemsProperties - unit test", () => {
         expect(changedProperties.getHasProperty(EntityPropertyList.PROP_POSITION)).toBe(true);
         expect(changedProperties.getHasProperty(EntityPropertyList.PROP_ALPHA)).toBe(true);
         expect(changedProperties.getHasProperty(EntityPropertyList.PROP_DIMENSIONS)).toBe(false);
+    });
+
+    test("Can encode an entity edit with all properties fitting and less than max size property flags", () => {
+        // eslint-disable-next-line max-len
+        const EXPECTED_MESSAGE = "00b685f1f20a000600b71d53802fcc483393a79a49670175874000fff000020000000000000000401000a82f40b6ee8946ccb50402b88d72a546f02594";
+
+        const properties = {
+            lastEdited: 1688896885851574n,  // Date.now() as count of 100ns ticks since the Unix epoch + 44 clock skew.
+            lastEditedBy: new Uuid("a82f40b6-ee89-46cc-b504-02b88d72a546"),
+            entityType: EntityType.Box,
+            color: { red: 240, green: 37, blue: 148 }
+        };
+        const requestedProperties = EntityItemProperties.getChangedProperties(properties);
+        const didntFitProperties = new EntityPropertyFlags();
+        const entityID = new Uuid("b71d5380-2fcc-4833-93a7-9a4967017587");
+
+        const messageData = new MessageData();
+        messageData.buffer = new Uint8Array(UDT.MAX_PACKET_SIZE);
+        messageData.dataPosition = 0;
+        messageData.packetSize = UDT.MAX_PACKET_SIZE;
+
+        const appendState = EntityItemProperties.encodeEntityEditPacket(/* PacketTypeValue.EntityEdit, */ entityID,
+            properties, messageData, requestedProperties, didntFitProperties);
+        expect(appendState).toBe(AppendState.COMPLETED);
+        expect(didntFitProperties.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(false);
+        expect(didntFitProperties.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(false);
+        expect(didntFitProperties.isEmpty()).toBe(true);
+        expect(buffer2hex(messageData.buffer.slice(0, messageData.dataPosition))).toBe(EXPECTED_MESSAGE);
+        expect(messageData.dataPosition).toBe(EXPECTED_MESSAGE.length / 2);
+    });
+
+    test("Can encode an entity edit with some properties that didn't fit", () => {
+        /* eslint-disable max-len */
+        // Full message from previous test:
+        //                       "00b685f1f20a000600b71d53802fcc483393a79a49670175874000fff000020000000000000000401000a82f40b6ee8946ccb50402b88d72a546f02594";
+        // Partial message without trailing color properties:
+        const EXPECTED_MESSAGE = "00b685f1f20a000600b71d53802fcc483393a79a49670175874000fff00000000000000000000040f02594";
+        // PROP_LAST_EDITED_BY not written so bit flipped to 0:                                ^
+        /* eslint-enable max-len */
+        const EXPECTED_MESSAGE_BYTES = EXPECTED_MESSAGE.length / 2;
+
+        const properties = {
+            lastEdited: 1688896885851574n,  // Date.now() as count of 100ns ticks since the Unix epoch + 44 clock skew.
+            lastEditedBy: new Uuid("a82f40b6-ee89-46cc-b504-02b88d72a546"),
+            entityType: EntityType.Box,
+            color: { red: 240, green: 37, blue: 148 }
+        };
+        const requestedProperties = EntityItemProperties.getChangedProperties(properties);
+        const didntFitProperties = new EntityPropertyFlags();
+        const entityID = new Uuid("b71d5380-2fcc-4833-93a7-9a4967017587");
+
+        const BUFFER_SIZE = EXPECTED_MESSAGE_BYTES + 6 + 2;  // 6 bytes for non-reduced packet flags, 2 bytes extra.
+        const messageData = new MessageData();
+        messageData.buffer = new Uint8Array(BUFFER_SIZE);
+        messageData.dataPosition = 0;
+        messageData.packetSize = BUFFER_SIZE;
+
+        const appendState = EntityItemProperties.encodeEntityEditPacket(/* PacketTypeValue.EntityEdit, */ entityID,
+            properties, messageData, requestedProperties, didntFitProperties);
+
+        expect(appendState).toBe(AppendState.PARTIAL);
+        expect(didntFitProperties.isEmpty()).toBe(false);
+        expect(didntFitProperties.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(true);
+        expect(didntFitProperties.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(false);
+        expect(buffer2hex(messageData.buffer.slice(0, messageData.dataPosition))).toBe(EXPECTED_MESSAGE);
+        expect(messageData.dataPosition).toBe(EXPECTED_MESSAGE.length / 2);
+    });
+
+    test("If no entity properties can fit in the packet then the return value reflects this", () => {
+
+        const properties = {
+            lastEdited: 1688896885851574n,  // Date.now() as count of 100ns ticks since the Unix epoch + 44 clock skew.
+            lastEditedBy: new Uuid("a82f40b6-ee89-46cc-b504-02b88d72a546"),
+            entityType: EntityType.Box,
+            color: { red: 240, green: 37, blue: 148 }
+        };
+        const requestedProperties = EntityItemProperties.getChangedProperties(properties);
+        const didntFitProperties = new EntityPropertyFlags();
+        const entityID = new Uuid("b71d5380-2fcc-4833-93a7-9a4967017587");
+
+        const BUFFER_SIZE = 48;
+        const messageData = new MessageData();
+        messageData.buffer = new Uint8Array(BUFFER_SIZE);
+        messageData.dataPosition = 0;
+        messageData.packetSize = BUFFER_SIZE;
+
+        const appendState = EntityItemProperties.encodeEntityEditPacket(/* PacketTypeValue.EntityEdit, */ entityID,
+            properties, messageData, requestedProperties, didntFitProperties);
+
+        expect(appendState).toBe(AppendState.NONE);
+        expect(didntFitProperties.isEmpty()).toBe(false);
+        expect(didntFitProperties.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(true);
+        expect(didntFitProperties.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(true);
+        expect(messageData.dataPosition).toBe(0);
     });
 
 });

--- a/tests/domain/entities/EntityItemProperties.unit.test.js
+++ b/tests/domain/entities/EntityItemProperties.unit.test.js
@@ -122,7 +122,7 @@ describe("EntityItemsProperties - unit test", () => {
         const didntFitProperties = new EntityPropertyFlags();
         const entityID = new Uuid("b71d5380-2fcc-4833-93a7-9a4967017587");
 
-        const BUFFER_SIZE = 48;
+        const BUFFER_SIZE = 48;  // 2 available bytes after property flags.
         const messageData = new MessageData();
         messageData.buffer = new Uint8Array(BUFFER_SIZE);
         messageData.dataPosition = 0;

--- a/tests/domain/entities/EntityItemProperties.unit.test.js
+++ b/tests/domain/entities/EntityItemProperties.unit.test.js
@@ -1,0 +1,39 @@
+//
+//  EntityItemProperties.unit.test.js
+//
+//  Created by David Rowe on 26 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import EntityItemProperties from "../../../src/domain/entities/EntityItemProperties";
+import { EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+
+
+describe("EntityItemsProperties - unit test", () => {
+
+    test("No changed properties are calculated for empty properties value", () => {
+        const properties = {};
+        const changedProperties = EntityItemProperties.getChangedProperties(properties);
+        expect(changedProperties.isEmpty()).toBe(true);
+        for (const property in EntityPropertyList) {  // eslint-disable-line
+            expect(changedProperties.getHasProperty(EntityPropertyList[property])).toBe(false);
+        }
+    });
+
+    test("Can calculate top-level changed properties", () => {
+        const properties = {
+            position: { x: 0, y: 0, z: 0 },
+            alpha: 0.5
+        };
+        const changedProperties = EntityItemProperties.getChangedProperties(properties);
+        expect(changedProperties.isEmpty()).toBe(false);
+        expect(changedProperties.getHasProperty(EntityPropertyList.PROP_POSITION)).toBe(true);
+        expect(changedProperties.getHasProperty(EntityPropertyList.PROP_ALPHA)).toBe(true);
+        expect(changedProperties.getHasProperty(EntityPropertyList.PROP_DIMENSIONS)).toBe(false);
+    });
+
+});

--- a/tests/domain/entities/EntityPropertyFlags.unit.test.js
+++ b/tests/domain/entities/EntityPropertyFlags.unit.test.js
@@ -32,7 +32,7 @@ describe("EntityPropertyFlags - unit test", () => {
         expect(entityPropertyFlags.isEmpty()).toBe(false);
         entityPropertyFlags.setHasProperty(EntityPropertyList.PROP_POSITION, false);
         expect(entityPropertyFlags.getHasProperty(EntityPropertyList.PROP_POSITION)).toBe(false);
-        expect(entityPropertyFlags.isEmpty()).toBe(false);  // Length isn't reset.
+        expect(entityPropertyFlags.isEmpty()).toBe(true);
     });
 
 });

--- a/tests/domain/entities/EntityPropertyFlags.unit.test.js
+++ b/tests/domain/entities/EntityPropertyFlags.unit.test.js
@@ -14,9 +14,10 @@ import { EntityPropertyFlags, EntityPropertyList } from "../../../src/domain/ent
 describe("EntityPropertyFlags - unit test", () => {
     /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-    test("Can access EntityPRopertyList values", () => {
+    test("Can access EntityPropertyList values", () => {
         expect(EntityPropertyList.PROP_PAGED_PROPERTY).toBe(0);
         expect(EntityPropertyList.PROP_DERIVED_34).toBe(126);
+        expect(EntityPropertyList.PROP_LAST_ITEM).toBe(126);
         expect(EntityPropertyList.PROP_AFTER_LAST_ITEM).toBe(127);
         expect(EntityPropertyList.PROP_MAX_PARTICLES).toBe(92);
         expect(EntityPropertyList.PROP_MINOR_TICK_MARKS_COLOR).toBe(110);

--- a/tests/domain/entities/EntityPropertyFlags.unit.test.js
+++ b/tests/domain/entities/EntityPropertyFlags.unit.test.js
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import { EntityPropertyFlags, EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+import EntityPropertyFlags, { EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
 
 describe("EntityPropertyFlags - unit test", () => {
     /* eslint-disable @typescript-eslint/no-magic-numbers */

--- a/tests/domain/entities/EntityPropertyFlags.unit.test.js
+++ b/tests/domain/entities/EntityPropertyFlags.unit.test.js
@@ -1,0 +1,37 @@
+//
+//  EntityPropertyFlags.unit.test.js
+//
+//  Created by David Rowe on 27 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { EntityPropertyFlags, EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+
+describe("EntityPropertyFlags - unit test", () => {
+    /* eslint-disable @typescript-eslint/no-magic-numbers */
+
+    test("Can access EntityPRopertyList values", () => {
+        expect(EntityPropertyList.PROP_PAGED_PROPERTY).toBe(0);
+        expect(EntityPropertyList.PROP_DERIVED_34).toBe(126);
+        expect(EntityPropertyList.PROP_AFTER_LAST_ITEM).toBe(127);
+        expect(EntityPropertyList.PROP_MAX_PARTICLES).toBe(92);
+        expect(EntityPropertyList.PROP_MINOR_TICK_MARKS_COLOR).toBe(110);
+    });
+
+    test("Can use EntityPropertyFlags", () => {
+        const entityPropertyFlags = new EntityPropertyFlags();
+        expect(entityPropertyFlags.isEmpty()).toBe(true);
+        expect(entityPropertyFlags.getHasProperty(EntityPropertyList.PROP_POSITION)).toBe(false);
+        entityPropertyFlags.setHasProperty(EntityPropertyList.PROP_POSITION, true);
+        expect(entityPropertyFlags.getHasProperty(EntityPropertyList.PROP_POSITION)).toBe(true);
+        expect(entityPropertyFlags.isEmpty()).toBe(false);
+        entityPropertyFlags.setHasProperty(EntityPropertyList.PROP_POSITION, false);
+        expect(entityPropertyFlags.getHasProperty(EntityPropertyList.PROP_POSITION)).toBe(false);
+        expect(entityPropertyFlags.isEmpty()).toBe(false);  // Length isn't reset.
+    });
+
+});

--- a/tests/domain/entities/EntityTypes.unit.test.js
+++ b/tests/domain/entities/EntityTypes.unit.test.js
@@ -16,7 +16,7 @@ describe("EntityTypes - unit tests", () => {
     test("Can get entity types", () => {
         expect(EntityType.Unknown).toBe(0);
         expect(EntityType.Box).toBe(1);
-        expect(EntityType.NUM_TYPES).toBe(17);
+        expect(EntityType.NUM_TYPES).toBe(17);  // eslint-disable-line @typescript-eslint/no-magic-numbers
     });
 
 });

--- a/tests/domain/entities/EntityTypes.unit.test.js
+++ b/tests/domain/entities/EntityTypes.unit.test.js
@@ -1,0 +1,22 @@
+//
+//  EntityTypes.unit.test.js
+//
+//  Created by David Rowe on 19 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { EntityType } from "../../../src/domain/entities/EntityTypes";
+
+describe("EntityTypes - unit tests", () => {
+
+    test("Can get entity types", () => {
+        expect(EntityType.Unknown).toBe(0);
+        expect(EntityType.Box).toBe(1);
+        expect(EntityType.NUM_TYPES).toBe(17);
+    });
+
+});

--- a/tests/domain/entities/ImageEntityItem.unit.test.js
+++ b/tests/domain/entities/ImageEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import ImageEntityItem from "../../../src/domain/entities/ImageEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 
 
 describe("ImageEntityItem - unit tests", () => {
@@ -24,7 +24,7 @@ describe("ImageEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/LightEntityItem.unit.test.js
+++ b/tests/domain/entities/LightEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import LightEntityItem from "../../../src/domain/entities/LightEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 
 
 describe("LightEntityItem - unit tests", () => {
@@ -24,7 +24,7 @@ describe("LightEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/MaterialEntityItem.unit.test.js
+++ b/tests/domain/entities/MaterialEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import MaterialEntityItem from "../../../src/domain/entities/MaterialEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 
 
 describe("MaterialEntityItem - unit tests", () => {
@@ -24,7 +24,7 @@ describe("MaterialEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/ModelEntityItem.unit.test.js
+++ b/tests/domain/entities/ModelEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import ModelEntityItem from "../../../src/domain/entities/ModelEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 import ShapeType from "../../../src/domain/shared/ShapeType";
 
 
@@ -25,7 +25,7 @@ describe("ModelEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/ParticleEffectEntityItem.unit.test.js
+++ b/tests/domain/entities/ParticleEffectEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import ParticleEffectEntityItem from "../../../src/domain/entities/ParticleEffectEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 import ShapeType from "../../../src/domain/shared/ShapeType";
 
 
@@ -25,7 +25,7 @@ describe("ParticleEffectEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len
@@ -90,7 +90,7 @@ describe("ParticleEffectEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/ShapeEntityItem.unit.test.js
+++ b/tests/domain/entities/ShapeEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import ShapeEntityItem from "../../../src/domain/entities/ShapeEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 
 
 describe("ShapeEntityItem - unit tests", () => {
@@ -24,7 +24,7 @@ describe("ShapeEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         const bufferHex = "00b4ef0000803f000000000000803f0000803f00000000000000000800547269616e676c65";

--- a/tests/domain/entities/TextEntityItem.unit.test.js
+++ b/tests/domain/entities/TextEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import TextEntityItem from "../../../src/domain/entities/TextEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 
 
 describe("TextEntityItem - unit tests", () => {
@@ -24,7 +24,7 @@ describe("TextEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/WebEntityItem.unit.test.js
+++ b/tests/domain/entities/WebEntityItem.unit.test.js
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import WebEntityItem from "../../../src/domain/entities/WebEntityItem";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 
 describe("WebEntityItem - unit tests", () => {
 
@@ -23,7 +23,7 @@ describe("WebEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/entities/ZoneEntityItem.unit.test.js
+++ b/tests/domain/entities/ZoneEntityItem.unit.test.js
@@ -9,10 +9,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import EntityPropertyFlags from "../../../src/domain/entities/EntityPropertyFlags";
 import ZoneEntityItem from "../../../src/domain/entities/ZoneEntityItem";
 import AvatarPriorityMode from "../../../src/domain/shared/AvatarPriorityMode";
 import ComponentMode from "../../../src/domain/shared/ComponentMode";
-import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
 import ShapeType from "../../../src/domain/shared/ShapeType";
 
 
@@ -27,7 +27,7 @@ describe("ZoneEntityItem - unit tests", () => {
         }));
 
         const encodedFlags = new DataView(bufferArray.buffer);
-        const propertyFlags = new PropertyFlags();
+        const propertyFlags = new EntityPropertyFlags();
         propertyFlags.decode(encodedFlags, encodedFlags.byteLength);
 
         // eslint-disable-next-line max-len

--- a/tests/domain/networking/LimitedNodeList.unit.test.js
+++ b/tests/domain/networking/LimitedNodeList.unit.test.js
@@ -25,7 +25,7 @@ import ContextManager from "../../../src/domain/shared/ContextManager";
 import Uuid from "../../../src/domain/shared/Uuid";
 
 
-describe("LimitedNodeList - integration tests", () => {
+describe("LimitedNodeList - unit tests", () => {
 
     /* eslint-disable @typescript-eslint/no-magic-numbers */
     /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
@@ -328,7 +328,7 @@ describe("LimitedNodeList - integration tests", () => {
         expect(LimitedNodeList.connectReasonToString(27)).toBe("Invalid");
     });
 
-    test("Can set and get domain permissions", (done) => {
+    test("Can set and get domain kick permissions", (done) => {
         const limitedNodeList = new LimitedNodeList(contextID);
         limitedNodeList.canKickChanged.connect(() => {
             expect(limitedNodeList.getThisNodeCanKick()).toBe(true);
@@ -338,6 +338,42 @@ describe("LimitedNodeList - integration tests", () => {
         expect(limitedNodeList.getThisNodeCanKick()).toBe(false);
         const newPermissions = new NodePermissions();
         newPermissions.permissions = NodePermissions.Permission.canKick;
+        limitedNodeList.setPermissions(newPermissions);
+    });
+
+    test("Can set and get domain editing permissions", (done) => {
+        const limitedNodeList = new LimitedNodeList(contextID);
+        let hasCanRezChanged = false;
+        let hasCanRezTempChanged = false;
+        limitedNodeList.canRezChanged.connect(() => {
+            hasCanRezChanged = true;
+            expect(limitedNodeList.getThisNodeCanRez()).toBe(true);
+        });
+        limitedNodeList.canRezTmpChanged.connect(() => {
+            hasCanRezTempChanged = true;
+            expect(limitedNodeList.getThisNodeCanRezTmp()).toBe(true);
+        });
+        limitedNodeList.canGetAndSetPrivateUserDataChanged.connect(() => {
+            expect(limitedNodeList.getThisNodeCanGetAndSetPrivateUserData()).toBe(true);
+            expect(hasCanRezChanged).toBe(true);
+            expect(hasCanRezTempChanged).toBe(true);
+            done();
+        });
+
+        expect(limitedNodeList.getThisNodeCanRez()).toBe(false);
+        expect(limitedNodeList.getThisNodeCanRezTmp()).toBe(false);
+        expect(limitedNodeList.getThisNodeCanGetAndSetPrivateUserData()).toBe(false);
+        let newPermissions = new NodePermissions();
+        newPermissions.permissions = NodePermissions.Permission.canRezPermanentEntities;
+        limitedNodeList.setPermissions(newPermissions);
+        newPermissions = new NodePermissions();
+        newPermissions.permissions = NodePermissions.Permission.canRezPermanentEntities
+            + NodePermissions.Permission.canRezTemporaryEntities;
+        limitedNodeList.setPermissions(newPermissions);
+        newPermissions = new NodePermissions();
+        newPermissions.permissions = NodePermissions.Permission.canRezPermanentEntities
+            + NodePermissions.Permission.canRezTemporaryEntities
+            + NodePermissions.Permission.canGetAndSetPrivateUserData;
         limitedNodeList.setPermissions(newPermissions);
     });
 

--- a/tests/domain/networking/packets/EntityData.unit.test.js
+++ b/tests/domain/networking/packets/EntityData.unit.test.js
@@ -119,7 +119,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].acceleration.y).toBeCloseTo(0, 2);
         expect(info[0].acceleration.z).toBeCloseTo(0, 2);
         expect(info[0].damping).toBeCloseTo(0, 2);
-        expect(info[0].angularDampling).toBeCloseTo(0, 2);
+        expect(info[0].angularDamping).toBeCloseTo(0, 2);
         expect(info[0].restitution).toBeCloseTo(0.5, 3);
         expect(info[0].friction).toBeCloseTo(0.5, 3);
         expect(info[0].lifetime).toBeCloseTo(-1, 2);
@@ -247,7 +247,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].acceleration.y).toBeCloseTo(0, 2);
         expect(info[0].acceleration.z).toBeCloseTo(0, 2);
         expect(info[0].damping).toBeUndefined();
-        expect(info[0].angularDampling).toBeUndefined();
+        expect(info[0].angularDamping).toBeUndefined();
         expect(info[0].restitution).toBeCloseTo(0.5, 3);
         expect(info[0].friction).toBeCloseTo(0.5, 3);
         expect(info[0].lifetime).toBeCloseTo(-1, 2);
@@ -394,7 +394,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].acceleration.y).toBeCloseTo(0, 2);
         expect(info[1].acceleration.z).toBeCloseTo(0, 2);
         expect(info[1].damping).toBeCloseTo(0, 2);
-        expect(info[1].angularDampling).toBeCloseTo(0, 2);
+        expect(info[1].angularDamping).toBeCloseTo(0, 2);
         expect(info[1].restitution).toBeCloseTo(0.5, 3);
         expect(info[1].friction).toBeCloseTo(0.5, 3);
         expect(info[1].lifetime).toBeCloseTo(-1, 2);
@@ -551,7 +551,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].acceleration.y).toBeCloseTo(0, 2);
         expect(info[0].acceleration.z).toBeCloseTo(0, 2);
         expect(info[0].damping).toBe(0);
-        expect(info[0].angularDampling).toBe(0);
+        expect(info[0].angularDamping).toBe(0);
         expect(info[0].restitution).toBeCloseTo(0.5, 3);
         expect(info[0].friction).toBeCloseTo(0.5, 3);
         expect(info[0].lifetime).toBeCloseTo(-1, 2);
@@ -698,7 +698,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].acceleration.y).toBeCloseTo(0, 2);
         expect(info[1].acceleration.z).toBeCloseTo(0, 2);
         expect(info[1].damping).toBeCloseTo(0, 2);
-        expect(info[1].angularDampling).toBeCloseTo(0, 2);
+        expect(info[1].angularDamping).toBeCloseTo(0, 2);
         expect(info[1].restitution).toBeCloseTo(0.5, 3);
         expect(info[1].friction).toBeCloseTo(0.5, 3);
         expect(info[1].lifetime).toBeCloseTo(-1, 2);

--- a/tests/domain/networking/packets/EntityData.unit.test.js
+++ b/tests/domain/networking/packets/EntityData.unit.test.js
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import { HostType } from "../../../../src/domain/entities/EntityItem"; }
+import { HostType } from "../../../../src/domain/entities/EntityItem";
 import EntityData from "../../../../src/domain/networking/packets/EntityData";
 import AvatarPriorityMode from "../../../../src/domain/shared/AvatarPriorityMode";
 import ComponentMode from "../../../../src/domain/shared/ComponentMode";

--- a/tests/domain/networking/packets/EntityData.unit.test.js
+++ b/tests/domain/networking/packets/EntityData.unit.test.js
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import { HostType } from "../../../../src/domain/entities/EntityItem"; }
 import EntityData from "../../../../src/domain/networking/packets/EntityData";
 import AvatarPriorityMode from "../../../../src/domain/shared/AvatarPriorityMode";
 import ComponentMode from "../../../../src/domain/shared/ComponentMode";
@@ -66,6 +67,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].created).toBe(1655451515775649n);
         expect(info[0].lastEditedBy instanceof Uuid).toBe(true);
         expect(info[0].lastEditedBy.stringify()).toBe("e0a1aa03-b104-4476-a927-28a804e9d44a");
+        expect(info[0].entityHostType).toBe(HostType.DOMAIN);
         expect(info[0].queryAACube.corner.x).toBeCloseTo(0.6662073, 3);
         expect(info[0].queryAACube.corner.y).toBeCloseTo(-12.5329, 3);
         expect(info[0].queryAACube.corner.z).toBeCloseTo(2.7988767, 3);
@@ -214,6 +216,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].registrationPoint).toBeUndefined();
         expect(info[0].created).toBeUndefined();
         expect(info[0].lastEditedBy).toBeUndefined();
+        expect(info[0].entityHostType).toBe(HostType.DOMAIN);
         expect(info[0].queryAACube).toBeUndefined();
         expect(info[0].canCastShadow).toBeUndefined();
         expect(info[0].renderLayer).toBeUndefined();
@@ -339,6 +342,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].created).toBe(1655893407496516n);
         expect(info[1].lastEditedBy instanceof Uuid).toBe(true);
         expect(info[1].lastEditedBy.stringify()).toBe("49c19ac5-e413-4579-80e8-a0899444cb01");
+        expect(info[1].entityHostType).toBe(HostType.DOMAIN);
         expect(info[1].queryAACube.corner.x).toBeCloseTo(-1.548620, 3);
         expect(info[1].queryAACube.corner.y).toBeCloseTo(-2.31339, 3);
         expect(info[1].queryAACube.corner.z).toBeCloseTo(-0.900225, 3);
@@ -497,6 +501,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].created).toBe(1657627173666914n);
         expect(info[0].lastEditedBy instanceof Uuid).toBe(true);
         expect(info[0].lastEditedBy.stringify()).toBe("1026cbdd-6414-4861-bf88-99a21bed3fd2");
+        expect(info[0].entityHostType).toBe(HostType.DOMAIN);
         expect(info[0].queryAACube.corner.x).toBeCloseTo(-0.68387, 4);
         expect(info[0].queryAACube.corner.y).toBeCloseTo(-1.85178, 4);
         expect(info[0].queryAACube.corner.z).toBeCloseTo(0.52001, 4);
@@ -641,6 +646,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].created).toBe(1657627191786141n);
         expect(info[1].lastEditedBy instanceof Uuid).toBe(true);
         expect(info[1].lastEditedBy.stringify()).toBe("1026cbdd-6414-4861-bf88-99a21bed3fd2");
+        expect(info[1].entityHostType).toBe(HostType.DOMAIN);
         expect(info[1].queryAACube.corner.x).toBeCloseTo(-1.18520, 4);
         expect(info[1].queryAACube.corner.y).toBeCloseTo(-1.83080, 4);
         expect(info[1].queryAACube.corner.z).toBeCloseTo(0.49136, 4);

--- a/tests/domain/networking/packets/EntityEdit.unit.test.js
+++ b/tests/domain/networking/packets/EntityEdit.unit.test.js
@@ -1,0 +1,88 @@
+//
+//  EntityEdit.unit.test.js
+//
+//  Created by David Rowe on 23 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import EntityItemProperties from "../../../../src/domain/entities/EntityItemProperties";
+import EntityPropertyFlags from "../../../../src/domain/entities/EntityPropertyFlags";
+import { EntityType } from "../../../../src/domain/entities/EntityTypes";
+import EntityEdit from "../../../../src/domain/networking/packets/EntityEdit";
+import PacketType from "../../../../src/domain/networking/udt/PacketHeaders";
+import UDT from "../../../../src/domain/networking/udt/UDT";
+import NLPacket from "../../../../src/domain/networking/NLPacket";
+import Uuid from "../../../../src/domain/shared/Uuid";
+
+import { buffer2hex } from "../../../testUtils";
+
+
+describe("EntityEdit - unit tests", () => {
+
+    test("Can write an EntityEdit packet that changes top-level properties", () => {
+        /* eslint-disable @typescript-eslint/no-magic-numbers, max-len */
+
+        // From C++ with 2-byte octcode:
+        /*
+        const EXPECTED_PACKET = "000000002d8500000000000000000000000000000000000000006089f1f20a0006000100b685f1f20a000600b71d53802fcc483393a79a49670175874000fff000020000000000000000401000a82f40b6ee8946ccb50402b88d72a546f02594";
+        // With 2-byte octcode replaced with 1-byte 0x00 empty octcode:                              ^^^^
+        // With low-order digits of timestamp zeroed out:                            ^^^^^^
+        // Reliable, not unreliable:   ^
+        */
+        const EXPECTED_PACKET = "000000402d850000000000000000000000000000000000000000003c98f20a00060000b685f1f20a000600b71d53802fcc483393a79a49670175874000fff000020000000000000000401000a82f40b6ee8946ccb50402b88d72a546f02594";
+
+        /* eslint-enable max-len */
+
+        const mockDateNow = jest.spyOn(Date, "now").mockImplementation(() => {
+            return 168889688;
+        });
+
+        const properties = {
+            lastEdited: 1688896885851574n,  // Date.now() as count of 100ns ticks since the Unix epoch + 44 clock skew.
+            lastEditedBy: new Uuid("a82f40b6-ee89-46cc-b504-02b88d72a546"),
+            entityType: EntityType.Box,
+            color: { red: 240, green: 37, blue: 148 }
+        };
+        const requestedProperties = EntityItemProperties.getChangedProperties(properties);
+        const didntFitProperties = new EntityPropertyFlags();
+        const entityEditDetails = {
+            entityID: new Uuid("b71d5380-2fcc-4833-93a7-9a4967017587"),
+            properties,
+            requestedProperties,
+            didntFitProperties
+        };
+        const packet = EntityEdit.write(entityEditDetails);
+
+        expect(packet instanceof NLPacket).toBe(true);
+        expect(packet.getType()).toBe(PacketType.EntityEdit);
+        expect(packet.isReliable()).toBe(true);
+        const packetSize = packet.getDataSize();
+        expect(packetSize).toBe(packet.getMessageData().dataPosition);
+        expect(packetSize).toBeGreaterThan(0);
+        expect(packetSize).toBeLessThan(UDT.MAX_PACKET_SIZE);
+        expect(buffer2hex(packet.getMessageData().buffer.slice(0, packetSize))).toBe(EXPECTED_PACKET);
+        expect(packetSize).toBe(EXPECTED_PACKET.length / 2);
+
+        expect(entityEditDetails.didntFitProperties.length()).toBe(0);
+
+        mockDateNow.mockReset(); // eslint-disable-line @typescript-eslint/no-unsafe-call
+        /* eslint-enable @typescript-eslint/no-magic-numbers */
+    });
+
+    /*
+    test("Can write an EntityEdit packet that changes group properties", () => {
+        expect(false).toBe(true);
+    });
+    */
+
+    /*
+    test("Writing a property that won't fit in a packet returns null", () => {
+        expect(false).toBe(true);
+    })
+    */
+
+});

--- a/tests/domain/networking/packets/PacketScribe.unit.test.js
+++ b/tests/domain/networking/packets/PacketScribe.unit.test.js
@@ -60,6 +60,8 @@ describe("Packets - unit tests", () => {
         expect(typeof PacketScribe.EntityData.read).toBe("function");
         expect(typeof PacketScribe.EntityQuery).toBe("object");
         expect(typeof PacketScribe.EntityQuery.write).toBe("function");
+        expect(typeof PacketScribe.EntityEdit).toBe("object");
+        expect(typeof PacketScribe.EntityEdit.write).toBe("function");
         expect(typeof PacketScribe.DomainServerConnectionToken).toBe("object");
         expect(typeof PacketScribe.DomainServerConnectionToken.read).toBe("function");
         expect(typeof PacketScribe.DomainDisconnectRequest).toBe("object");

--- a/tests/domain/octree/OctreeEditPacketSender.unit.test.js
+++ b/tests/domain/octree/OctreeEditPacketSender.unit.test.js
@@ -18,6 +18,7 @@ import ContextManager from "../../../src/domain/shared/ContextManager";
 import PacketType from "../../../src/domain/networking/udt/PacketHeaders";
 import NLPacket from "../../../src/domain/networking/NLPacket";
 import NodeList from "../../../src/domain/networking/NodeList";
+import SockAddr from "../../../src/domain/networking/SockAddr";
 import OctreeEditPacketSender from "../../../src/domain/octree/OctreeEditPacketSender";
 
 
@@ -82,7 +83,11 @@ describe("OctreeEditPacketSender - unit tests", () => {
 
         const mockSoloNodeOfType = jest.spyOn(ContextManager.get(contextID, NodeList), "soloNodeOfType")
             .mockImplementation(() => {
-                return {};  // Entity server node.
+                return {
+                    getActiveSocket: () => {
+                        return new SockAddr();
+                    }
+                };  // Entity server node.
             });
         const mockSendPacket = jest.spyOn(ContextManager.get(contextID, NodeList), "sendPacket")
             .mockImplementation((editMessage) => {

--- a/tests/domain/octree/OctreeEditPacketSender.unit.test.js
+++ b/tests/domain/octree/OctreeEditPacketSender.unit.test.js
@@ -1,0 +1,101 @@
+//
+//  OctreeEditPacketSender.unit.test.js
+//
+//  Created by David Rowe on 20 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { webcrypto } from "crypto";
+globalThis.crypto = webcrypto;
+
+import AccountManager from "../../../src/domain/networking/AccountManager";
+import AddressManager from "../../../src/domain/networking/AddressManager";
+import ContextManager from "../../../src/domain/shared/ContextManager";
+import PacketType from "../../../src/domain/networking/udt/PacketHeaders";
+import NLPacket from "../../../src/domain/networking/NLPacket";
+import NodeList from "../../../src/domain/networking/NodeList";
+import OctreeEditPacketSender from "../../../src/domain/octree/OctreeEditPacketSender";
+
+
+describe("OctreeEditPacketSender - unit tests", () => {
+
+    test("An OctreeEditPacketSender can be obtained from the ContextManager", () => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, OctreeEditPacketSender, contextID);
+        const octreeEditPacketSender = ContextManager.get(contextID, OctreeEditPacketSender);
+        expect(octreeEditPacketSender instanceof OctreeEditPacketSender).toBe(true);
+    });
+
+    test("A warning is logged when try to send a packet without an entity server connection", () => {
+        let lastWarning = "";
+        const warn = jest.spyOn(console, "warn").mockImplementation((message) => {
+            lastWarning = message;  // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+        });
+
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, OctreeEditPacketSender, contextID);
+        const octreeEditPacketSender = ContextManager.get(contextID, OctreeEditPacketSender);
+
+        const nlPacket = new NLPacket(PacketType.EntityEdit);
+        octreeEditPacketSender.queueOctreeEditMessage(nlPacket);  // eslint-disable-line @typescript-eslint/no-unsafe-call
+        expect(lastWarning).toBe("[EntityServer] Could not send edit message because not connected.");
+
+        warn.mockRestore();
+    });
+
+    test("Asserts if try to send a non-entity packet", () => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, OctreeEditPacketSender, contextID);
+        const octreeEditPacketSender = ContextManager.get(contextID, OctreeEditPacketSender);
+
+        let lastAssert = "";
+        try {
+            const nlPacket = new NLPacket(PacketType.DomainListRequest);
+            octreeEditPacketSender.queueOctreeEditMessage(nlPacket);  // eslint-disable-line @typescript-eslint/no-unsafe-call
+        } catch (e) {
+            // eslint-disable-next-line
+            lastAssert = e.message;
+        }
+        expect(lastAssert).toBe("Assertion failed! queueOctreeEditMessage() unexpected packet type: 13");
+    });
+
+    test("Can send an NLPacket to the entity server", (done) => {
+        const contextID = ContextManager.createContext();
+        ContextManager.set(contextID, AccountManager, contextID);
+        ContextManager.set(contextID, AddressManager);
+        ContextManager.set(contextID, NodeList, contextID);
+        ContextManager.set(contextID, OctreeEditPacketSender, contextID);
+        const octreeEditPacketSender = ContextManager.get(contextID, OctreeEditPacketSender);
+
+        const mockSoloNodeOfType = jest.spyOn(ContextManager.get(contextID, NodeList), "soloNodeOfType")
+            .mockImplementation(() => {
+                return {};  // Entity server node.
+            });
+        const mockSendPacket = jest.spyOn(ContextManager.get(contextID, NodeList), "sendPacket")
+            .mockImplementation((editMessage) => {
+                expect(editMessage.getType()).toBe(PacketType.EntityEdit);  // eslint-disable-line
+                mockSendPacket.mockRestore();
+                mockSoloNodeOfType.mockRestore();
+                done();
+            });
+
+        const nlPacket = new NLPacket(PacketType.EntityEdit);
+        octreeEditPacketSender.queueOctreeEditMessage(nlPacket);  // eslint-disable-line @typescript-eslint/no-unsafe-call
+    });
+
+    // WEBRTC TODO: Test an NLPacketList can be sent to the entity server using an EntityAdd message.
+
+});

--- a/tests/domain/octree/OctreeElement.unit.test.js
+++ b/tests/domain/octree/OctreeElement.unit.test.js
@@ -1,0 +1,22 @@
+//
+//  OctreeElement.unit.test.js
+//
+//  Created by David Rowe on 29 Jun 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { AppendState } from "../../../src/domain/octree/OctreeElement";
+
+
+describe("OctreeElement - unit tests", () => {
+
+    test("AppendState values can be accessed", () => {
+        expect(AppendState.COMPLETED).toBe(0);
+        expect(AppendState.PARTIAL).toBe(1);
+        expect(AppendState.NONE).toBe(2);
+    });
+});

--- a/tests/domain/octree/OctreePacketData.unit.test.js
+++ b/tests/domain/octree/OctreePacketData.unit.test.js
@@ -21,7 +21,35 @@ import { buffer2hex } from "../../testUtils";
 describe("OctreePacketData - unit tests", () => {
     /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-    test("Can write a color value to a packet", () => {
+    test("Error if try to write an invalid color value", () => {
+        let errorMessage = "";
+        const error = jest.spyOn(console, "error").mockImplementation((...message) => {
+            errorMessage = message.join(" ");
+        });
+
+        const data = new DataView(new ArrayBuffer(10));
+        const context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, true);
+
+        let value = "aabbcc";
+        let bytesWritten = OctreePacketData.appendColorValue(data, 2, EntityPropertyList.PROP_COLOR, value, context);
+        expect(bytesWritten).toBe(0);
+        expect(errorMessage).toBe("[EntityServer] Cannot write invalid color value to packet!");
+
+        value = { red: 100, green: 150, blue: "" };
+        bytesWritten = OctreePacketData.appendColorValue(data, 2, EntityPropertyList.PROP_COLOR, value, context);
+        expect(bytesWritten).toBe(0);
+        expect(errorMessage).toBe("[EntityServer] Cannot write invalid color value to packet!");
+
+        error.mockRestore();
+    });
+
+    test("Can write a color value", () => {
         // Successful write.
         let data = new DataView(new ArrayBuffer(10));
         let value = { red: 100, green: 150, blue: 200 };
@@ -57,6 +85,29 @@ describe("OctreePacketData - unit tests", () => {
         expect(context.propertiesWritten.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(false);
         expect(context.propertyCount).toBe(0);
         expect(context.appendState).toBe(AppendState.PARTIAL);
+    });
+
+    test("Error if try to write an invalid UUID value", () => {
+        let errorMessage = "";
+        const error = jest.spyOn(console, "error").mockImplementation((...message) => {
+            errorMessage = message.join(" ");
+        });
+
+        const data = new DataView(new ArrayBuffer(10));
+        const context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+
+        const value = "aabbcc";
+        const bytesWritten = OctreePacketData.appendColorValue(data, 2, EntityPropertyList.PROP_LAST_EDITED_BY, value, context);
+        expect(bytesWritten).toBe(0);
+        expect(errorMessage).toBe("[EntityServer] Cannot write invalid color value to packet!");
+
+        error.mockRestore();
     });
 
     test("Can write a UUID value", () => {

--- a/tests/domain/octree/OctreePacketData.unit.test.js
+++ b/tests/domain/octree/OctreePacketData.unit.test.js
@@ -1,0 +1,118 @@
+//
+//  OctreePacketData.unit.test.js
+//
+//  Created by David Rowe on 17 Jul 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import EntityPropertyFlags, { EntityPropertyList } from "../../../src/domain/entities/EntityPropertyFlags";
+import { AppendState } from "../../../src/domain/octree/OctreeElement";
+import OctreePacketData from "../../../src/domain/octree/OctreePacketData";
+import Uuid from "../../../src/domain/shared/Uuid";
+
+import "../../../src/domain/shared/DataViewExtensions";
+import { buffer2hex } from "../../testUtils";
+
+
+describe("OctreePacketData - unit tests", () => {
+    /* eslint-disable @typescript-eslint/no-magic-numbers */
+
+    test("Can write a color value to a packet", () => {
+        // Successful write.
+        let data = new DataView(new ArrayBuffer(10));
+        let value = { red: 100, green: 150, blue: 200 };
+        let context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, true);
+        let bytesWritten = OctreePacketData.appendColorValue(data, 2, value, context);
+        expect(bytesWritten).toBe(3);
+        expect(buffer2hex(data.buffer)).toEqual("00006496c80000000000");
+        expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(false);
+        expect(context.propertiesWritten.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(true);
+        expect(context.propertyCount).toBe(1);
+        expect(context.appendState).toBe(AppendState.COMPLETED);
+
+        // Unsuccessful write.
+        data = new DataView(new ArrayBuffer(10));
+        value = { red: 100, green: 150, blue: 200 };
+        context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, true);
+        bytesWritten = OctreePacketData.appendColorValue(data, 8, value, context);
+        expect(bytesWritten).toBe(0);
+        expect(buffer2hex(data.buffer)).toEqual("00000000000000000000");
+        expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(true);
+        expect(context.propertiesWritten.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(false);
+        expect(context.propertyCount).toBe(0);
+        expect(context.appendState).toBe(AppendState.PARTIAL);
+    });
+
+    test("Can write a UUID value", () => {
+        // Successful write of null value.
+        let data = new DataView(new ArrayBuffer(24));
+        let value = new Uuid();
+        let context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+        let bytesWritten = OctreePacketData.appendUUIDValue(data, 2, value, context);
+        expect(bytesWritten).toBe(2);
+        expect(buffer2hex(data.buffer)).toEqual("000000000000000000000000000000000000000000000000");
+        expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(false);
+        expect(context.propertiesWritten.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(true);
+        expect(context.propertyCount).toBe(1);
+        expect(context.appendState).toBe(AppendState.COMPLETED);
+
+        // Successful write of non-null value.
+        data = new DataView(new ArrayBuffer(24));
+        value = new Uuid("a3eda01ec4de456dbf07858a26c5a648");
+        context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+        bytesWritten = OctreePacketData.appendUUIDValue(data, 2, value, context);
+        expect(bytesWritten).toBe(18);
+        expect(buffer2hex(data.buffer)).toEqual("00001000a3eda01ec4de456dbf07858a26c5a64800000000");
+        expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(false);
+        expect(context.propertiesWritten.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(true);
+        expect(context.propertyCount).toBe(1);
+        expect(context.appendState).toBe(AppendState.COMPLETED);
+
+        // Unsuccessful write.
+        data = new DataView(new ArrayBuffer(10));
+        value = new Uuid("a3eda01ec4de456dbf07858a26c5a648");
+        context = {
+            propertiesToWrite: new EntityPropertyFlags(),
+            propertiesWritten: new EntityPropertyFlags(),
+            propertyCount: 0,
+            appendState: AppendState.COMPLETED
+        };
+        context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
+        bytesWritten = OctreePacketData.appendUUIDValue(data, 2, value, context);
+        expect(bytesWritten).toBe(0);
+        expect(buffer2hex(data.buffer)).toEqual("00000000000000000000");
+        expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(true);
+        expect(context.propertiesWritten.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(false);
+        expect(context.propertyCount).toBe(0);
+        expect(context.appendState).toBe(AppendState.PARTIAL);
+    });
+
+});

--- a/tests/domain/octree/OctreePacketData.unit.test.js
+++ b/tests/domain/octree/OctreePacketData.unit.test.js
@@ -32,7 +32,7 @@ describe("OctreePacketData - unit tests", () => {
             appendState: AppendState.COMPLETED
         };
         context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, true);
-        let bytesWritten = OctreePacketData.appendColorValue(data, 2, value, context);
+        let bytesWritten = OctreePacketData.appendColorValue(data, 2, EntityPropertyList.PROP_COLOR, value, context);
         expect(bytesWritten).toBe(3);
         expect(buffer2hex(data.buffer)).toEqual("00006496c80000000000");
         expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(false);
@@ -50,7 +50,7 @@ describe("OctreePacketData - unit tests", () => {
             appendState: AppendState.COMPLETED
         };
         context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_COLOR, true);
-        bytesWritten = OctreePacketData.appendColorValue(data, 8, value, context);
+        bytesWritten = OctreePacketData.appendColorValue(data, 8, EntityPropertyList.PROP_COLOR, value, context);
         expect(bytesWritten).toBe(0);
         expect(buffer2hex(data.buffer)).toEqual("00000000000000000000");
         expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_COLOR)).toBe(true);
@@ -70,7 +70,7 @@ describe("OctreePacketData - unit tests", () => {
             appendState: AppendState.COMPLETED
         };
         context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
-        let bytesWritten = OctreePacketData.appendUUIDValue(data, 2, value, context);
+        let bytesWritten = OctreePacketData.appendUUIDValue(data, 2, EntityPropertyList.PROP_LAST_EDITED_BY, value, context);
         expect(bytesWritten).toBe(2);
         expect(buffer2hex(data.buffer)).toEqual("000000000000000000000000000000000000000000000000");
         expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(false);
@@ -88,7 +88,7 @@ describe("OctreePacketData - unit tests", () => {
             appendState: AppendState.COMPLETED
         };
         context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
-        bytesWritten = OctreePacketData.appendUUIDValue(data, 2, value, context);
+        bytesWritten = OctreePacketData.appendUUIDValue(data, 2, EntityPropertyList.PROP_LAST_EDITED_BY, value, context);
         expect(bytesWritten).toBe(18);
         expect(buffer2hex(data.buffer)).toEqual("00001000a3eda01ec4de456dbf07858a26c5a64800000000");
         expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(false);
@@ -106,7 +106,7 @@ describe("OctreePacketData - unit tests", () => {
             appendState: AppendState.COMPLETED
         };
         context.propertiesToWrite.setHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY, true);
-        bytesWritten = OctreePacketData.appendUUIDValue(data, 2, value, context);
+        bytesWritten = OctreePacketData.appendUUIDValue(data, 2, EntityPropertyList.PROP_LAST_EDITED_BY, value, context);
         expect(bytesWritten).toBe(0);
         expect(buffer2hex(data.buffer)).toEqual("00000000000000000000");
         expect(context.propertiesToWrite.getHasProperty(EntityPropertyList.PROP_LAST_EDITED_BY)).toBe(true);

--- a/tests/domain/shared/ByteCountCoded.unit.test.js
+++ b/tests/domain/shared/ByteCountCoded.unit.test.js
@@ -10,6 +10,7 @@
 //
 
 import ByteCountCoded from "../../../src/domain/shared/ByteCountCoded";
+import { buffer2hex } from "../../testUtils";
 
 
 describe("ByteCountCoded - unit tests", () => {
@@ -26,9 +27,8 @@ describe("ByteCountCoded - unit tests", () => {
         let data = new DataView(bufferArray.buffer);
         let codec = new ByteCountCoded();
         let bytesConsumed = codec.decode(data, bufferArray.length);
-
         expect(bytesConsumed).toBe(1);
-        expect(codec.data).toBe(4);
+        expect(codec.data).toBe(4n);
 
         // 2 bytes encoded.
         bufferHex = "8bfafffe3f";
@@ -38,9 +38,8 @@ describe("ByteCountCoded - unit tests", () => {
         data = new DataView(bufferArray.buffer);
         codec = new ByteCountCoded();
         bytesConsumed = codec.decode(data, bufferArray.length);
-
         expect(bytesConsumed).toBe(2);
-        expect(codec.data).toBe(6132);
+        expect(codec.data).toBe(6132n);
 
         // 3 bytes encoded.
         bufferHex = "d20e80ffff8fff";
@@ -50,9 +49,55 @@ describe("ByteCountCoded - unit tests", () => {
         data = new DataView(bufferArray.buffer);
         codec = new ByteCountCoded();
         bytesConsumed = codec.decode(data, bufferArray.length);
-
         expect(bytesConsumed).toBe(3);
-        expect(codec.data).toBe(11785);
+        expect(codec.data).toBe(11785n);
+
+        // 0 encoding.
+        bufferHex = "00dc";
+        bufferArray = new Uint8Array(bufferHex.match(/[\da-f]{2}/giu).map(function (hex) {
+            return parseInt(hex, 16);
+        }));
+        data = new DataView(bufferArray.buffer);
+        codec = new ByteCountCoded();
+        bytesConsumed = codec.decode(data, bufferArray.length);
+        expect(bytesConsumed).toBe(1);
+        expect(codec.data).toBe(0n);
+    });
+
+    test("Can byte count encode data", () => {
+        const codec = new ByteCountCoded();
+
+        // 1 byte encoded.
+        let bufferHex = "1000";
+        codec.data = 4n;
+        let bufferArray = new Uint8Array(2);
+        let bytesWritten = codec.encode(new DataView(bufferArray.buffer, 0));
+        expect(bytesWritten).toBe(1);
+        expect(buffer2hex(bufferArray)).toBe(bufferHex);
+
+        // 2 bytes encoded.
+        bufferHex = "8bfa0000";
+        codec.data = 6132n;
+        bufferArray = new Uint8Array(4);
+        bytesWritten = codec.encode(new DataView(bufferArray.buffer, 0));
+        expect(bytesWritten).toBe(2);
+        expect(buffer2hex(bufferArray)).toBe(bufferHex);
+
+        // 3 bytes encoded.
+        bufferHex = "d20e80000000";
+        codec.data = 11785n;
+        bufferArray = new Uint8Array(6);
+        bytesWritten = codec.encode(new DataView(bufferArray.buffer, 0));
+        expect(bytesWritten).toBe(3);
+        expect(buffer2hex(bufferArray)).toBe(bufferHex);
+
+        // 0 encoding.
+        bufferHex = "0000";
+        codec.data = 0n;
+        bufferArray = new Uint8Array(2);
+        bytesWritten = codec.encode(new DataView(bufferArray.buffer, 0));
+        expect(bytesWritten).toBe(1);
+        expect(buffer2hex(bufferArray)).toBe(bufferHex);
     });
 
 });

--- a/tests/domain/shared/JSONExtensions.unit.test.js
+++ b/tests/domain/shared/JSONExtensions.unit.test.js
@@ -17,6 +17,7 @@
 */
 
 import { bigintReplacer, bigintReviver } from "../../../src/domain/shared/JSONExtensions";
+import Uuid from "../../../src/domain/shared/Uuid";
 
 
 describe("JSON extensions - unit tests", () => {
@@ -31,10 +32,21 @@ describe("JSON extensions - unit tests", () => {
         expect(jsonString).toBe("{\"value\":\"170141183460469231731687303715884105731n\",\"other\":123}");
     });
 
+    test("Can stringify objects with Uuid values", () => {
+        const value = new Uuid(2n ** 127n + 3n);  // Most-significant and 2 least-significant bits.
+        const object = {
+            value,
+            other: 123
+        };
+        const jsonString = JSON.stringify(object, bigintReplacer);
+        expect(jsonString).toBe("{\"value\":\"170141183460469231731687303715884105731n\",\"other\":123}");
+    });
+
     test("Can parse objects with bigint values", () => {
         const jsonString = "{\"value\":\"170141183460469231731687303715884105731n\",\"other\":123}";
         const object = JSON.parse(jsonString, bigintReviver);
         expect(object.value).toBe(2n ** 127n + 3n);
         expect(object.other).toBe(123);
     });
+
 });

--- a/tests/domain/shared/JSONExtensions.unit.test.js
+++ b/tests/domain/shared/JSONExtensions.unit.test.js
@@ -1,0 +1,40 @@
+//
+//  JSONExtensions.unit.test.js
+//
+//  Created by David Rowe on 3 Jul 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/*
+    eslint-disable
+    @typescript-eslint/no-magic-numbers,
+    @typescript-eslint/no-unsafe-assignment,
+    @typescript-eslint/no-unsafe-member-access
+*/
+
+import { bigintReplacer, bigintReviver } from "../../../src/domain/shared/JSONExtensions";
+
+
+describe("JSON extensions - unit tests", () => {
+
+    test("Can stringify objects with bigint values", () => {
+        const value = 2n ** 127n + 3n;  // Most-significant and 2 least-significant bits.
+        const object = {
+            value,
+            other: 123
+        };
+        const jsonString = JSON.stringify(object, bigintReplacer);
+        expect(jsonString).toBe("{\"value\":\"170141183460469231731687303715884105731n\",\"other\":123}");
+    });
+
+    test("Can parse objects with bigint values", () => {
+        const jsonString = "{\"value\":\"170141183460469231731687303715884105731n\",\"other\":123}";
+        const object = JSON.parse(jsonString, bigintReviver);
+        expect(object.value).toBe(2n ** 127n + 3n);
+        expect(object.other).toBe(123);
+    });
+});

--- a/tests/domain/shared/PropertyFlags.unit.test.js
+++ b/tests/domain/shared/PropertyFlags.unit.test.js
@@ -10,6 +10,7 @@
 //
 
 import PropertyFlags from "../../../src/domain/shared/PropertyFlags";
+import { buffer2hex } from "../../testUtils";
 
 
 describe("EntityData - unit tests", () => {
@@ -61,6 +62,7 @@ describe("EntityData - unit tests", () => {
         const bytesConsumed = propertyFlags.decode(data, 32, 0);
         expect(bytesConsumed).toBe(16);
         expect(propertyFlags.isEmpty()).toBe(false);
+        expect(propertyFlags.getEncodedLength()).toBe(16);
 
         expect(propertyFlags.getHasProperty(0)).toBe(false);
         expect(propertyFlags.getHasProperty(1)).toBe(false);
@@ -174,5 +176,168 @@ describe("EntityData - unit tests", () => {
         expect(propertyFlags.getHasProperty(109)).toBe(true);
         expect(propertyFlags.getHasProperty(110)).toBe(true);
         expect(propertyFlags.getHasProperty(111)).toBe(false);
+
+        expect(propertyFlags.length()).toBe(111);
+    });
+
+    test("Can encode property flags", () => {
+        const bufferHex = "fffe3fffcdfffffffffffff8381ffffe";
+
+        const propertyFlags = new PropertyFlags();
+        propertyFlags.setHasProperty(2, true);
+        propertyFlags.setHasProperty(3, true);
+        propertyFlags.setHasProperty(4, true);
+        propertyFlags.setHasProperty(5, true);
+        propertyFlags.setHasProperty(6, true);
+        propertyFlags.setHasProperty(7, true);
+        propertyFlags.setHasProperty(8, true);
+        propertyFlags.setHasProperty(9, true);
+        propertyFlags.setHasProperty(10, true);
+        propertyFlags.setHasProperty(11, true);
+        propertyFlags.setHasProperty(12, true);
+        propertyFlags.setHasProperty(13, true);
+        propertyFlags.setHasProperty(14, true);
+        propertyFlags.setHasProperty(15, true);
+        propertyFlags.setHasProperty(16, true);
+        propertyFlags.setHasProperty(17, true);
+        propertyFlags.setHasProperty(20, true);
+        propertyFlags.setHasProperty(21, true);
+        propertyFlags.setHasProperty(23, true);
+        propertyFlags.setHasProperty(24, true);
+        propertyFlags.setHasProperty(25, true);
+        propertyFlags.setHasProperty(26, true);
+        propertyFlags.setHasProperty(27, true);
+        propertyFlags.setHasProperty(28, true);
+        propertyFlags.setHasProperty(29, true);
+        propertyFlags.setHasProperty(30, true);
+        propertyFlags.setHasProperty(31, true);
+        propertyFlags.setHasProperty(32, true);
+        propertyFlags.setHasProperty(33, true);
+        propertyFlags.setHasProperty(34, true);
+        propertyFlags.setHasProperty(35, true);
+        propertyFlags.setHasProperty(36, true);
+        propertyFlags.setHasProperty(37, true);
+        propertyFlags.setHasProperty(38, true);
+        propertyFlags.setHasProperty(39, true);
+        propertyFlags.setHasProperty(40, true);
+        propertyFlags.setHasProperty(41, true);
+        propertyFlags.setHasProperty(42, true);
+        propertyFlags.setHasProperty(43, true);
+        propertyFlags.setHasProperty(44, true);
+        propertyFlags.setHasProperty(45, true);
+        propertyFlags.setHasProperty(46, true);
+        propertyFlags.setHasProperty(47, true);
+        propertyFlags.setHasProperty(48, true);
+        propertyFlags.setHasProperty(49, true);
+        propertyFlags.setHasProperty(50, true);
+        propertyFlags.setHasProperty(51, true);
+        propertyFlags.setHasProperty(52, true);
+        propertyFlags.setHasProperty(53, true);
+        propertyFlags.setHasProperty(54, true);
+        propertyFlags.setHasProperty(55, true);
+        propertyFlags.setHasProperty(56, true);
+        propertyFlags.setHasProperty(57, true);
+        propertyFlags.setHasProperty(58, true);
+        propertyFlags.setHasProperty(59, true);
+        propertyFlags.setHasProperty(60, true);
+        propertyFlags.setHasProperty(61, true);
+        propertyFlags.setHasProperty(62, true);
+        propertyFlags.setHasProperty(63, true);
+        propertyFlags.setHasProperty(64, true);
+        propertyFlags.setHasProperty(65, true);
+        propertyFlags.setHasProperty(66, true);
+        propertyFlags.setHasProperty(67, true);
+        propertyFlags.setHasProperty(68, true);
+        propertyFlags.setHasProperty(69, true);
+        propertyFlags.setHasProperty(70, true);
+        propertyFlags.setHasProperty(71, true);
+        propertyFlags.setHasProperty(72, true);
+        propertyFlags.setHasProperty(73, true);
+        propertyFlags.setHasProperty(74, true);
+        propertyFlags.setHasProperty(75, true);
+        propertyFlags.setHasProperty(76, true);
+        propertyFlags.setHasProperty(82, true);
+        propertyFlags.setHasProperty(83, true);
+        propertyFlags.setHasProperty(84, true);
+        propertyFlags.setHasProperty(91, true);
+        propertyFlags.setHasProperty(92, true);
+        propertyFlags.setHasProperty(93, true);
+        propertyFlags.setHasProperty(94, true);
+        propertyFlags.setHasProperty(95, true);
+        propertyFlags.setHasProperty(96, true);
+        propertyFlags.setHasProperty(97, true);
+        propertyFlags.setHasProperty(98, true);
+        propertyFlags.setHasProperty(99, true);
+        propertyFlags.setHasProperty(100, true);
+        propertyFlags.setHasProperty(101, true);
+        propertyFlags.setHasProperty(102, true);
+        propertyFlags.setHasProperty(103, true);
+        propertyFlags.setHasProperty(104, true);
+        propertyFlags.setHasProperty(105, true);
+        propertyFlags.setHasProperty(106, true);
+        propertyFlags.setHasProperty(107, true);
+        propertyFlags.setHasProperty(108, true);
+        propertyFlags.setHasProperty(109, true);
+        propertyFlags.setHasProperty(110, true);
+
+        expect(propertyFlags.length()).toBe(111);
+
+        const bufferArray = new Uint8Array(16);
+        const data = new DataView(bufferArray.buffer);
+
+        const bytesWritten = propertyFlags.encode(data, 0);
+        expect(bytesWritten).toBe(16);
+        expect(propertyFlags.getEncodedLength()).toBe(16);
+
+        const bytes = buffer2hex(bufferArray);
+        expect(bytes).toBe(bufferHex);
+    });
+
+    test("Can construct from another PropertyFlags object", () => {
+        const bufferHex = "fffe3fffcdfffffffffffff8381ffffe";
+        const bufferArray = new Uint8Array(bufferHex.match(/[\da-f]{2}/giu).map(function (hex) {
+            return parseInt(hex, 16);
+        }));
+        const data = new DataView(bufferArray.buffer);
+        const propertyFlags = new PropertyFlags();
+
+        const bytesConsumed = propertyFlags.decode(data, 16, 0);
+        expect(bytesConsumed).toBe(16);
+        expect(propertyFlags.length()).toBe(111);
+        const propertyFlagsCopy = new PropertyFlags(propertyFlags);
+        expect(propertyFlagsCopy.length()).toBe(111);
+
+        const originalArray = new Uint8Array(16);
+        const originalData = new DataView(originalArray.buffer);
+        propertyFlags.encode(originalData, 0);
+        const originalBytes = buffer2hex(bufferArray);
+        expect(originalBytes).toBe(bufferHex);
+
+        const copyArray = new Uint8Array(16);
+        const copyData = new DataView(copyArray.buffer);
+        propertyFlags.encode(copyData, 0);
+        const copyBytes = buffer2hex(bufferArray);
+        expect(copyBytes).toBe(bufferHex);
+
+    });
+
+    test("Can output debug information", () => {
+        let debugMessage = "";
+        const debug = jest.spyOn(console, "debug").mockImplementation((...message) => {
+            debugMessage = message.join(" ");
+        });
+
+        const propertyFlags = new PropertyFlags();
+        propertyFlags.setHasProperty(0, true);
+        propertyFlags.setHasProperty(1, true);
+        propertyFlags.setHasProperty(8, true);
+        expect(propertyFlags.getHasProperty(0)).toBe(true);
+        expect(propertyFlags.getHasProperty(1)).toBe(true);
+        expect(propertyFlags.getHasProperty(8)).toBe(true);
+        propertyFlags.debugDumpBits();
+
+        expect(debugMessage).toBe("bits: 110000001");
+
+        debug.mockReset();
     });
 });

--- a/tests/domain/shared/PropertyFlags.unit.test.js
+++ b/tests/domain/shared/PropertyFlags.unit.test.js
@@ -29,18 +29,25 @@ describe("EntityData - unit tests", () => {
         propertyFlags.setHasProperty(0, true);
         expect(propertyFlags.getHasProperty(0)).toBe(true);
         expect(propertyFlags.isEmpty()).toBe(false);
+        expect(propertyFlags.length()).toBe(1);
 
         // Clear 1st bit.
         propertyFlags.setHasProperty(0, false);
         expect(propertyFlags.getHasProperty(0)).toBe(false);
+        expect(propertyFlags.isEmpty()).toBe(true);
+        expect(propertyFlags.length()).toBe(0);
 
         // Set 2nd bit.
         propertyFlags.setHasProperty(1, true);
         expect(propertyFlags.getHasProperty(1)).toBe(true);
+        expect(propertyFlags.isEmpty()).toBe(false);
+        expect(propertyFlags.length()).toBe(2);
 
         // Clear 2nd bit.
         propertyFlags.setHasProperty(1, false);
         expect(propertyFlags.getHasProperty(1)).toBe(false);
+        expect(propertyFlags.isEmpty()).toBe(true);
+        expect(propertyFlags.length()).toBe(0);
 
         // Set 1st, 2nd and 9th bits.
         propertyFlags.setHasProperty(0, true);
@@ -49,6 +56,8 @@ describe("EntityData - unit tests", () => {
         expect(propertyFlags.getHasProperty(0)).toBe(true);
         expect(propertyFlags.getHasProperty(1)).toBe(true);
         expect(propertyFlags.getHasProperty(8)).toBe(true);
+        expect(propertyFlags.isEmpty()).toBe(false);
+        expect(propertyFlags.length()).toBe(9);
     });
 
     test("Can decode property flags", () => {
@@ -318,7 +327,34 @@ describe("EntityData - unit tests", () => {
         propertyFlags.encode(copyData, 0);
         const copyBytes = buffer2hex(bufferArray);
         expect(copyBytes).toBe(bufferHex);
+    });
 
+    test("Can copy from another PropertyFlags object", () => {
+        const bufferHex = "fffe3fffcdfffffffffffff8381ffffe";
+        const bufferArray = new Uint8Array(bufferHex.match(/[\da-f]{2}/giu).map(function (hex) {
+            return parseInt(hex, 16);
+        }));
+        const data = new DataView(bufferArray.buffer);
+        const propertyFlags = new PropertyFlags();
+
+        const bytesConsumed = propertyFlags.decode(data, 16, 0);
+        expect(bytesConsumed).toBe(16);
+        expect(propertyFlags.length()).toBe(111);
+        const propertyFlagsCopy = new PropertyFlags();
+        propertyFlagsCopy.copy(propertyFlags);
+        expect(propertyFlagsCopy.length()).toBe(111);
+
+        const originalArray = new Uint8Array(16);
+        const originalData = new DataView(originalArray.buffer);
+        propertyFlags.encode(originalData, 0);
+        const originalBytes = buffer2hex(bufferArray);
+        expect(originalBytes).toBe(bufferHex);
+
+        const copyArray = new Uint8Array(16);
+        const copyData = new DataView(copyArray.buffer);
+        propertyFlags.encode(copyData, 0);
+        const copyBytes = buffer2hex(bufferArray);
+        expect(copyBytes).toBe(bufferHex);
     });
 
     test("Can output debug information", () => {
@@ -334,10 +370,14 @@ describe("EntityData - unit tests", () => {
         expect(propertyFlags.getHasProperty(0)).toBe(true);
         expect(propertyFlags.getHasProperty(1)).toBe(true);
         expect(propertyFlags.getHasProperty(8)).toBe(true);
-        propertyFlags.debugDumpBits();
 
+        propertyFlags.debugDumpBits();
         expect(debugMessage).toBe("bits: 110000001");
+
+        propertyFlags.debugDumpBits("Test");
+        expect(debugMessage).toBe("Test bits: 110000001");
 
         debug.mockReset();
     });
+
 });

--- a/tests/domain/shared/PropertyFlags.unit.test.js
+++ b/tests/domain/shared/PropertyFlags.unit.test.js
@@ -16,12 +16,18 @@ describe("EntityData - unit tests", () => {
 
     /* eslint-disable @typescript-eslint/no-magic-numbers */
 
+    test("Can create an empty property flags", () => {
+        const propertyFlags = new PropertyFlags();
+        expect(propertyFlags.isEmpty()).toBe(true);
+    });
+
     test("Can set and get property flags", () => {
         const propertyFlags = new PropertyFlags();
 
         // Set 1st bit.
         propertyFlags.setHasProperty(0, true);
         expect(propertyFlags.getHasProperty(0)).toBe(true);
+        expect(propertyFlags.isEmpty()).toBe(false);
 
         // Clear 1st bit.
         propertyFlags.setHasProperty(0, false);
@@ -53,8 +59,8 @@ describe("EntityData - unit tests", () => {
         const propertyFlags = new PropertyFlags();
 
         const bytesConsumed = propertyFlags.decode(data, 32, 0);
-
         expect(bytesConsumed).toBe(16);
+        expect(propertyFlags.isEmpty()).toBe(false);
 
         expect(propertyFlags.getHasProperty(0)).toBe(false);
         expect(propertyFlags.getHasProperty(1)).toBe(false);


### PR DESCRIPTION
EntityServer API additions:
[x] `canRez`, `canRezTemp`, and `canGetAndSetPrivateUserData` domain permissions properties.
[x] `canRezChanged`, `canRezTempChanged`, and `canGetAndSetPrivateUserDataChanged` signals.
[ ] `addEntity()` method.
[ ] `cloneEntity()` method.
[ ] `editEntity()` method. _In progress._
[ ] `deleteEntity()` method.
[ ] `getEntityType()` method.
[ ] `entityExists()` method.

Entity property additions:
[x] `entityHostType` in common entity properties.

Example app:
[x] Report domain permisions properties.
[ ] ...
